### PR TITLE
fix: security hardening for web server and internal reader

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@ refresh_seconds=300
 data_dir=data
 server_baseurl=http://localhost:8000
 
+# Bind address for the HTTP server
+# Default: 127.0.0.1 (localhost only). Set to 0.0.0.0 to listen on all interfaces.
+bind_address=0.0.0.0
+
 # Internal RSS Reader (optional)
 # Set to 'true' to enable internal article viewer at /article/{feed}/{guid}
 # When enabled, RSS feed links point to internal reader instead of external websites

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ refresh_seconds=300
 data_dir=data
 max_item_per_feed=100
 server_baseurl=http://localhost:8000
+bind_address=0.0.0.0
 
 # Internal RSS Reader (optional)
 # Set to 'true' to enable internal article viewer
@@ -49,6 +50,7 @@ enable_internal_reader=false
 | `data_dir` | Directory for database and RSS files | `data` |
 | `max_item_per_feed` | Maximum items per RSS feed | `100` |
 | `server_baseurl` | Base URL for RSS feed links | Optional |
+| `bind_address` | Address the HTTP server binds to | `127.0.0.1` |
 | `enable_internal_reader` | Enable internal article viewer | `false` |
 
 ## Internal RSS Reader

--- a/common.py
+++ b/common.py
@@ -21,6 +21,7 @@ config = {
     "max_item_per_feed": int(os.getenv("max_item_per_feed", "100")),
     "server_baseurl": os.getenv("server_baseurl"),
     "enable_internal_reader": os.getenv("enable_internal_reader", "false").lower() == "true",
+    "bind_address": os.getenv("bind_address", "127.0.0.1"),
 }
 
 

--- a/database.py
+++ b/database.py
@@ -6,7 +6,7 @@ import datetime
 import email
 import hashlib
 
-from sqlalchemy import create_engine, Column, Integer, String, Text, DateTime, BLOB, Index, text
+from sqlalchemy import create_engine, event, Column, Integer, String, Text, DateTime, BLOB, Index, text
 from sqlalchemy.pool import NullPool
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
@@ -45,6 +45,13 @@ class Email(Base):
 
 data_dir = config.get("data_dir", "data")
 engine = create_engine(f"sqlite:///{data_dir}/emails.db", poolclass=NullPool)
+
+
+@event.listens_for(engine, "connect")
+def set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA journal_mode=WAL")
+    cursor.close()
 
 
 def migrate_database():

--- a/feed_server.py
+++ b/feed_server.py
@@ -4,6 +4,7 @@ A Simple python web server which serves RSS feeds and provides an internal reade
 """
 from __future__ import annotations
 
+import html as html_module
 import os
 import functools
 import http.server
@@ -16,7 +17,7 @@ from urllib.parse import unquote
 
 import database as db
 from common import logging, config
-from util import cleanse_content
+from util import cleanse_content, sanitize_html
 
 
 class RSSRequestHandler(http.server.SimpleHTTPRequestHandler):
@@ -144,6 +145,9 @@ class RSSRequestHandler(http.server.SimpleHTTPRequestHandler):
             if not html_content and text_content:
                 content = f"<pre>{content}</pre>"
 
+            # Sanitize HTML content to prevent XSS
+            content = sanitize_html(content)
+
             # Generate HTML response
             html = self.generate_article_html(subject_text, sender_email, date_text, content)
 
@@ -151,6 +155,7 @@ class RSSRequestHandler(http.server.SimpleHTTPRequestHandler):
             self.send_response(200)
             self.send_header("Content-type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(len(html.encode("utf-8"))))
+            self.send_security_headers()
             self.end_headers()
             self.wfile.write(html.encode("utf-8"))
 
@@ -187,6 +192,7 @@ class RSSRequestHandler(http.server.SimpleHTTPRequestHandler):
             self.send_response(200)
             self.send_header("Content-type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(len(html.encode("utf-8"))))
+            self.send_security_headers()
             self.end_headers()
             self.wfile.write(html.encode("utf-8"))
 
@@ -223,6 +229,7 @@ class RSSRequestHandler(http.server.SimpleHTTPRequestHandler):
             self.send_response(200)
             self.send_header("Content-type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(len(html.encode("utf-8"))))
+            self.send_security_headers()
             self.end_headers()
             self.wfile.write(html.encode("utf-8"))
 
@@ -241,6 +248,12 @@ class RSSRequestHandler(http.server.SimpleHTTPRequestHandler):
             str: Sanitized feed name (e.g., hello_mrdongnews_com)
         """
         return email_address.replace("@", "_").replace(".", "_")
+
+    def send_security_headers(self):
+        """Send security-related HTTP headers."""
+        self.send_header("Content-Security-Policy", "default-src 'self'; img-src * data:; style-src 'self' 'unsafe-inline'")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("X-Frame-Options", "DENY")
 
     def serve_static_file(self, filename):
         """
@@ -276,6 +289,7 @@ class RSSRequestHandler(http.server.SimpleHTTPRequestHandler):
             self.send_response(200)
             self.send_header("Content-type", mime_type)
             self.send_header("Content-Length", str(len(content)))
+            self.send_security_headers()
             self.end_headers()
             self.wfile.write(content)
 
@@ -296,19 +310,22 @@ class RSSRequestHandler(http.server.SimpleHTTPRequestHandler):
         Returns:
             str: Complete HTML page
         """
+        escaped_subject = html_module.escape(subject)
+        escaped_sender = html_module.escape(sender)
+        escaped_date = html_module.escape(date or '')
         return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{subject}</title>
+    <title>{escaped_subject}</title>
     <link rel="stylesheet" href="/static/reader.css">
 </head>
 <body>
     <article>
         <header>
-            <h1>{subject}</h1>
-            <p class="meta">From: {sender} | Date: {date}</p>
+            <h1>{escaped_subject}</h1>
+            <p class="meta">From: {escaped_sender} | Date: {escaped_date}</p>
         </header>
         <div class="content">
             {content}
@@ -332,10 +349,11 @@ class RSSRequestHandler(http.server.SimpleHTTPRequestHandler):
         """
         # Build page title and header
         if specific_sender:
-            page_title = f"Articles from {specific_sender}"
+            escaped_sender = html_module.escape(specific_sender)
+            page_title = f"Articles from {escaped_sender}"
             header_html = f"""
                 <header>
-                    <h1>Articles from {specific_sender}</h1>
+                    <h1>Articles from {escaped_sender}</h1>
                     <p class="meta">
                         Total articles: {len(articles)} |
                         <a href="/article" style="color: var(--link-color);">View all feeds</a>
@@ -354,7 +372,7 @@ class RSSRequestHandler(http.server.SimpleHTTPRequestHandler):
                 for sender, stats in sorted(senders.items(), key=lambda x: x[1]["latest"], reverse=True):
                     feed_stats_html += f"""
                         <li>
-                            <a href="/article/{stats['feed_name']}">{sender}</a>
+                            <a href="/article/{stats['feed_name']}">{html_module.escape(sender)}</a>
                             <span class="meta">({stats['count']} articles, last updated: {stats['latest'].strftime('%Y-%m-%d %H:%M')})</span>
                         </li>
                     """
@@ -376,10 +394,10 @@ class RSSRequestHandler(http.server.SimpleHTTPRequestHandler):
 
             articles_html += f"""
                 <li class='article-item'>
-                    <a href="{article_url}" class='article-title'>{article['subject']}</a>
+                    <a href="{article_url}" class='article-title'>{html_module.escape(article['subject'])}</a>
                     <div class="meta">
-                        From: <a href="/article/{feed_name}">{article['sender']}</a> |
-                        Date: {article['date']}
+                        From: <a href="/article/{feed_name}">{html_module.escape(article['sender'])}</a> |
+                        Date: {html_module.escape(article['date'] or '')}
                     </div>
                 </li>
             """

--- a/feed_server.py
+++ b/feed_server.py
@@ -12,7 +12,7 @@ import email
 import email.header
 import mimetypes
 from pathlib import Path
-from urllib.parse import unquote
+from urllib.parse import unquote, urlparse
 
 import database as db
 from common import logging, config
@@ -34,12 +34,14 @@ class RSSRequestHandler(http.server.SimpleHTTPRequestHandler):
         Serve a GET request with routing support.
         """
         # Block database files
-        if self.path.endswith(".db"):
+        parsed_path = urlparse(self.path).path
+        if parsed_path.endswith(".db"):
             self.send_error(404, "File not found")
             return
 
+        safe_path = self.path.replace('\n', '').replace('\r', '')
         logging.info(
-            f"Serving ip={self.client_address[0]} headers={self.headers} {self.path}"
+            f"Serving ip={self.client_address[0]} path={safe_path}"
         )
 
         # Route handling
@@ -156,7 +158,7 @@ class RSSRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         except Exception as e:
             logging.error(f"Error serving article {feed_name}/{guid}: {e}")
-            self.send_error(500, f"Internal server error: {str(e)}")
+            self.send_error(500, "Internal server error")
 
     def serve_article_list(self):
         """
@@ -192,7 +194,7 @@ class RSSRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         except Exception as e:
             logging.error(f"Error serving article list: {e}")
-            self.send_error(500, f"Internal server error: {str(e)}")
+            self.send_error(500, "Internal server error")
 
     def serve_feed_article_list(self, feed_name):
         """
@@ -228,7 +230,7 @@ class RSSRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         except Exception as e:
             logging.error(f"Error serving feed article list {feed_name}: {e}")
-            self.send_error(500, f"Internal server error: {str(e)}")
+            self.send_error(500, "Internal server error")
 
     def sanitize_feed_name(self, email_address):
         """
@@ -281,7 +283,7 @@ class RSSRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         except Exception as e:
             logging.error(f"Error serving static file {filename}: {e}")
-            self.send_error(500, f"Internal server error: {str(e)}")
+            self.send_error(500, "Internal server error")
 
     def generate_article_html(self, subject, sender, date, content):
         """
@@ -491,7 +493,8 @@ def run(
                          Defaults to "data/feed".
         port (int): The port number on which to run the server. Defaults to 8000.
     """
-    server_address = ("", port)
+    bind_address = config.get("bind_address", "127.0.0.1")
+    server_address = (bind_address, port)
 
     # Create a partial function that initializes the handler with the directory
     handler = functools.partial(handler_class, directory=directory)
@@ -501,10 +504,11 @@ def run(
     # If certfile and keyfile are provided, run the server with SSL
     if certfile and keyfile:
         context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
         context.load_cert_chain(certfile, keyfile)
         httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
 
-    logging.info(f"Serving {directory}/ to HTTP http://0.0.0.0:{port}/")
+    logging.info(f"Serving {directory}/ to HTTP http://{bind_address}:{port}/")
     httpd.serve_forever()
 
 

--- a/util.py
+++ b/util.py
@@ -102,3 +102,22 @@ def cleanse_content(content):
     # This pattern excludes ASCII values 9 (tab), 10 (newline), and 13 (carriage return), which are acceptable in XML.
     invalid_xml_chars = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F]")
     return invalid_xml_chars.sub("", content)
+
+
+def sanitize_html(content):
+    """Sanitize HTML content to prevent XSS while preserving safe formatting."""
+    if not content:
+        return content
+    # Remove script tags and content
+    content = re.sub(r'<script[^>]*>.*?</script>', '', content, flags=re.DOTALL | re.IGNORECASE)
+    # Remove style tags and content
+    content = re.sub(r'<style[^>]*>.*?</style>', '', content, flags=re.DOTALL | re.IGNORECASE)
+    # Remove dangerous tags (keep content between them)
+    for tag in ['iframe', 'object', 'embed', 'form', 'input', 'base', 'meta', 'link']:
+        content = re.sub(rf'</?{tag}[^>]*>', '', content, flags=re.IGNORECASE)
+    # Remove event handlers
+    content = re.sub(r'\s+on\w+\s*=\s*["\'][^"\']*["\']', '', content, flags=re.IGNORECASE)
+    content = re.sub(r'\s+on\w+\s*=\s*\S+', '', content, flags=re.IGNORECASE)
+    # Remove javascript: URLs
+    content = re.sub(r'(href|src|action)\s*=\s*["\']?\s*javascript:', r'\1="', content, flags=re.IGNORECASE)
+    return content


### PR DESCRIPTION
## Summary
- **XSS prevention**: HTML-escape subject/sender/date in templates, sanitize email body HTML (strip script/iframe/event handlers/javascript: URLs)
- **Security headers**: Add Content-Security-Policy, X-Content-Type-Options, X-Frame-Options
- **Server hardening**: Default bind to 127.0.0.1, generic 500 errors, fix .db bypass via query strings, log injection prevention, TLS 1.2 minimum, SQLite WAL mode
- **Docs**: Add `bind_address` config to README

## Test plan
- [ ] Verify internal reader renders articles correctly with escaped metadata
- [ ] Confirm malicious email content (script tags, event handlers) is stripped
- [ ] Check security headers present in responses (`curl -I`)
- [ ] Verify server binds to 127.0.0.1 by default, 0.0.0.0 when configured
- [ ] Confirm `.db?query=1` returns 404
- [ ] Verify TLS connections reject TLS 1.0/1.1