### PR TITLE
fix(img_proxy): /img returning 500 — duplicate assert_hostname kwarg

### DIFF
--- a/img_proxy.py
+++ b/img_proxy.py
@@ -81,12 +81,19 @@ class PinnedIPAdapter(HTTPAdapter):
         conn = super().get_connection_with_tls_context(
             request, verify, proxies=proxies, cert=cert
         )
-        # urllib3 HTTPSConnectionPool stores conn_kw as a dict of kwargs forwarded
-        # to each new HTTPSConnection. Copy-on-write to avoid mutating a shared pool.
+        # The returned "conn" is an HTTPSConnectionPool. urllib3 creates each
+        # concrete HTTPSConnection by passing (a) some attributes explicitly
+        # from the pool (`assert_hostname` is one of them) and (b) `**conn_kw`.
+        # Putting `assert_hostname` into conn_kw collides with the explicit
+        # kwarg → TypeError "got multiple values for assert_hostname".
+        # Set it as a pool attribute instead; urllib3 will forward it once.
+        if hasattr(conn, "assert_hostname"):
+            conn.assert_hostname = self.pinned_host
+        # server_hostname is not an explicit pool attribute, so passing it via
+        # conn_kw is the correct channel for TLS SNI.
         if hasattr(conn, "conn_kw"):
             conn.conn_kw = dict(conn.conn_kw or {})
             conn.conn_kw["server_hostname"] = self.pinned_host
-            conn.conn_kw["assert_hostname"] = self.pinned_host
         return conn
 
     def send(self, request, **kwargs):

--- a/tests/test_img_proxy.py
+++ b/tests/test_img_proxy.py
@@ -264,22 +264,28 @@ def test_fetch_image_rejects_documentation_range(monkeypatch):
 
 
 def test_pinned_ip_adapter_sets_tls_sni_for_https(monkeypatch):
-    """After URL rewrite to pinned IP, server_hostname and assert_hostname must
-    still be the real hostname — otherwise TLS cert validation fails for HTTPS."""
+    """After URL rewrite to pinned IP, TLS still needs the real hostname.
+
+    Contract:
+    - `server_hostname` goes into `conn_kw` (urllib3's channel for SNI)
+    - `assert_hostname` goes on the pool as an attribute (NOT in conn_kw);
+      urllib3 passes `assert_hostname` as an explicit kwarg at connection
+      creation, so putting it in `conn_kw` too would raise TypeError
+      'got multiple values for keyword argument' (prod regression 2026-04).
+    """
     import requests
     import requests.adapters
 
     adapter = img_proxy.PinnedIPAdapter(pinned_host="example.com", pinned_ip="93.184.216.34")
 
-    # Minimal fake pool to verify conn_kw is patched
     class FakePool:
         def __init__(self):
             self.conn_kw = {}
+            self.assert_hostname = None  # urllib3 default
 
     fake_conn = FakePool()
 
     def fake_super_get(self, request, verify, proxies=None, cert=None):
-        # Simulate what urllib3 would return — the pool keyed by the rewritten URL
         return fake_conn
 
     monkeypatch.setattr(
@@ -288,8 +294,14 @@ def test_pinned_ip_adapter_sets_tls_sni_for_https(monkeypatch):
         fake_super_get,
     )
 
-    # Build a minimal request object
     req = requests.Request("GET", "https://93.184.216.34:443/x.png").prepare()
     conn = adapter.get_connection_with_tls_context(req, verify=True)
+
+    # server_hostname channel: conn_kw
     assert conn.conn_kw.get("server_hostname") == "example.com"
-    assert conn.conn_kw.get("assert_hostname") == "example.com"
+    # assert_hostname channel: pool attribute, NOT conn_kw
+    assert conn.assert_hostname == "example.com"
+    assert "assert_hostname" not in conn.conn_kw, (
+        "putting assert_hostname in conn_kw collides with urllib3's explicit "
+        "kwarg and raises TypeError at connection creation"
+    )


### PR DESCRIPTION
## Summary

Production bug: every `/img?u=...&sig=...` returned 500. Reproduced locally against the Cloudflare R2 URL the user reported.

## Root cause

When the browser fetched `/img?u=...` (after the sub-project-2 TLS SNI fix), the proxy's `PinnedIPAdapter.get_connection_with_tls_context` put **both** `server_hostname` and `assert_hostname` into `conn_kw`. urllib3 then creates each `HTTPSConnection` by passing `assert_hostname` explicitly from the pool attribute **plus** `**pool.conn_kw` — duplicate keyword:

```
TypeError: urllib3.connection.HTTPSConnection() got multiple values
for keyword argument 'assert_hostname'
```

Our existing tests patched at the `HTTPAdapter.send` level, bypassing pool/connection construction entirely, so they never surfaced this.

## Fix

- `assert_hostname` → pool attribute (`conn.assert_hostname = self.pinned_host`). This is the channel urllib3 expects for it.
- `server_hostname` stays in `conn_kw` (urllib3's SNI channel).
- Test updated to lock in the contract: `conn_kw` must **not** contain `assert_hostname`.

## Verification

- Local reproduction against `https://pub-cb0321b52a854a95af8d6bb1688b2ecd.r2.dev/logo/logo_b52ec3efde15.png` now returns `200 image/png, 19097 bytes`.
- 127/127 tests pass. Ruff clean.

## Test plan

- [ ] CI green
- [ ] After merge+deploy, revisit https://email2rss.1kko.com/article/team_soonsal_com/83ac4d61a3e1235f85c7319b15c887f7 — images should load