### PR TITLE
fix(ui): nav flush + home link + logo-vs-content image extraction

### DIFF
--- a/img_proxy.py
+++ b/img_proxy.py
@@ -141,26 +141,31 @@ def fetch_image(url: str, secret: bytes) -> tuple[bytes, str]:
     """
     parsed = urlparse(url)
     if parsed.scheme not in ("http", "https"):
+        logger.info("fetch_image reject: bad scheme url=%r", url)
         abort(400)
 
     host = parsed.hostname
     if not host:
+        logger.info("fetch_image reject: no hostname url=%r", url)
         abort(400)
 
     port = parsed.port or (443 if parsed.scheme == "https" else 80)
 
     try:
         infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
-    except socket.gaierror:
+    except socket.gaierror as e:
+        logger.info("fetch_image reject: DNS failure host=%s err=%s", host, e)
         abort(502)
 
     resolved_ips = {info[4][0] for info in infos}
     if not resolved_ips:
+        logger.info("fetch_image reject: empty DNS resolution host=%s", host)
         abort(502)
 
     # Reject if ANY resolved address is non-public
     for ip_str in resolved_ips:
         if not _is_public_ip(ip_str):
+            logger.info("fetch_image reject: non-public IP host=%s ip=%s", host, ip_str)
             abort(403)
 
     pinned_ip = next(iter(resolved_ips))
@@ -184,10 +189,15 @@ def fetch_image(url: str, secret: bytes) -> tuple[bytes, str]:
 
     try:
         if resp.status_code != 200:
+            logger.info(
+                "fetch_image reject: upstream status=%s url=%s location=%s",
+                resp.status_code, url, resp.headers.get("Location", ""),
+            )
             abort(502)
 
         ctype = (resp.headers.get("Content-Type") or "").split(";")[0].strip().lower()
         if ctype not in ALLOWED_IMAGE_TYPES:
+            logger.info("fetch_image reject: bad content-type=%r url=%s", ctype, url)
             abort(415)
 
         body = bytearray()
@@ -195,6 +205,7 @@ def fetch_image(url: str, secret: bytes) -> tuple[bytes, str]:
             if chunk:
                 body.extend(chunk)
                 if len(body) > MAX_IMAGE_BYTES:
+                    logger.info("fetch_image reject: oversize url=%s", url)
                     abort(413)
 
         return bytes(body), ctype

--- a/reader.py
+++ b/reader.py
@@ -271,21 +271,32 @@ def extract_plain_text(msg) -> str:
 
 
 _TRACKING_FILENAME_HINTS = ("pixel", "track", "open", "beacon", "spacer")
+_BRAND_FILENAME_HINTS = ("logo", "brand", "header-image", "footer-image", "masthead", "sig-")
 _MIN_IMAGE_PX = 50
 
 
 def extract_preview_image(msg) -> str | None:
     """
-    Walk the MIME message's HTML body and return the first "usable" <img> URL,
-    or None. Used for landing-page thumbnails.
+    Walk the MIME message's HTML body and return the best "usable" <img> URL
+    for a landing-page thumbnail, or None.
 
-    Rules for "usable":
+    Selection strategy:
+    1. Collect all <img> candidates that pass the filter rules below.
+    2. If at least one candidate has both width and height declared, return the
+       candidate with the largest area (width × height). This beats the earlier
+       "first-usable" approach that tended to pick the newsletter logo, since
+       logos are usually near the top and smaller than the article's hero image.
+    3. If no candidate has declared dimensions, return the first one (best we
+       can do without rendering the email to measure images).
+
+    Filter rules (each applies before a candidate is considered):
     - src starts with http://, https://, or // (protocol-relative → https:)
-    - cid: and data: skipped (can't be re-served via the /img proxy from a list)
+    - cid: and data: URIs skipped
     - width=1 or height=1 skipped (tracking pixel)
-    - filename containing pixel/track/open/beacon/spacer skipped (case-insensitive)
-    - if width and height attributes are both declared, both must be >= 50
-    - otherwise accepted
+    - filename contains pixel/track/open/beacon/spacer → skipped (trackers)
+    - filename contains logo/brand/header-image/footer-image/masthead/sig-
+      → skipped (branding imagery)
+    - if both width and height are declared, both must be >= 50
     """
     import re
 
@@ -293,8 +304,9 @@ def extract_preview_image(msg) -> str | None:
     if not body_html:
         return None
 
-    # Find all <img ...> tags. We keep the regex narrow: we only inspect src/width/height.
-    # A full HTML parse is overkill for this single-field extraction.
+    candidates: list[tuple[int, str]] = []  # (area, src); area=-1 when unknown
+    first_unknown_area: str | None = None
+
     for match in re.finditer(r'<img\b([^>]*)>', body_html, flags=re.IGNORECASE):
         attrs_str = match.group(1)
         src = _attr(attrs_str, "src")
@@ -303,11 +315,9 @@ def extract_preview_image(msg) -> str | None:
         src = src.strip()
         lower_src = src.lower()
 
-        # Skip unsupported schemes
         if lower_src.startswith("cid:") or lower_src.startswith("data:"):
             continue
 
-        # Normalize protocol-relative
         if src.startswith("//"):
             src = "https:" + src
             lower_src = src.lower()
@@ -315,26 +325,35 @@ def extract_preview_image(msg) -> str | None:
         if not (lower_src.startswith("http://") or lower_src.startswith("https://")):
             continue
 
-        # Filename hint filter
+        # Filename hint filters — trackers AND branding imagery
         fname = lower_src.rsplit("/", 1)[-1]
         if any(hint in fname for hint in _TRACKING_FILENAME_HINTS):
+            continue
+        if any(hint in fname for hint in _BRAND_FILENAME_HINTS):
             continue
 
         width = _attr_int(attrs_str, "width")
         height = _attr_int(attrs_str, "height")
 
-        # 1x1 tracking pixel
         if width == 1 or height == 1:
             continue
 
-        # If both declared and either is below threshold, skip
         if width is not None and height is not None:
             if width < _MIN_IMAGE_PX or height < _MIN_IMAGE_PX:
                 continue
+            candidates.append((width * height, src))
+        else:
+            # No declared dimensions — remember the first so we can fall back
+            if first_unknown_area is None:
+                first_unknown_area = src
 
-        return src
+    # Prefer the largest declared candidate
+    if candidates:
+        candidates.sort(key=lambda c: c[0], reverse=True)
+        return candidates[0][1]
 
-    return None
+    # Fallback: first image with unknown dimensions
+    return first_unknown_area
 
 
 def _attr(attrs_str: str, name: str) -> str | None:

--- a/static/reader.css
+++ b/static/reader.css
@@ -34,8 +34,21 @@ body {
     line-height: 1.6;
     color: var(--text-color);
     background-color: var(--bg-color);
-    padding: 1rem;
+    margin: 0;
+    padding: 0;
 }
+
+/* Pages without an outer wrapper (e.g. /list) get horizontal padding via their
+   direct-child elements. Pages with their own wrappers (.article, .feed-rows)
+   set their own padding. */
+body > h1,
+body > p,
+body > ul,
+body > ol {
+    padding-left: 1rem;
+    padding-right: 1rem;
+}
+body > h1:first-of-type { padding-top: 1rem; }
 
 article {
     max-width: 900px;
@@ -166,16 +179,35 @@ h1 {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 1rem;
   padding: 0.75rem 1rem;
   border-bottom: 1px solid #e0e0e0;
   background: #fafafa;
 }
-.site-nav .nav-home { font-weight: 600; text-decoration: none; color: #222; }
+.site-nav__left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.site-nav .nav-home {
+  font-weight: 700;
+  text-decoration: none;
+  color: #222;
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
+}
+.site-nav .nav-link {
+  font-weight: 500;
+  text-decoration: none;
+  color: #555;
+  font-size: 0.9rem;
+}
+.site-nav .nav-link:hover { color: #222; }
 .site-nav .nav-search input[type="search"] {
   padding: 0.4rem 0.6rem;
   border: 1px solid #ccc;
   border-radius: 4px;
-  min-width: 250px;
+  min-width: 200px;
   font-size: 0.9rem;
 }
 
@@ -224,6 +256,8 @@ h1 {
 @media (prefers-color-scheme: dark) {
   .site-nav { background: #222; border-bottom-color: #444; }
   .site-nav .nav-home { color: #eee; }
+  .site-nav .nav-link { color: #aaa; }
+  .site-nav .nav-link:hover { color: #eee; }
   .site-nav .nav-search input[type="search"] {
     background: #333; border-color: #555; color: #eee;
   }

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,7 +9,10 @@
 </head>
 <body>
   <nav class="site-nav">
-    <a href="/article" class="nav-home">All Articles</a>
+    <div class="site-nav__left">
+      <a href="/" class="nav-home" aria-label="email2rss home">email2rss</a>
+      <a href="/article" class="nav-link">All Articles</a>
+    </div>
     <form class="nav-search" action="/search" method="get">
       <input type="search" name="q" placeholder="Search..." value="{{ search_q or '' }}" required>
     </form>

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -314,3 +314,41 @@ def test_extract_preview_image_accepts_image_without_declared_dimensions():
     # No width/height attributes → we can't verify size, accept it
     msg = _make_html_msg('<img src="http://x.com/maybe.png">')
     assert reader.extract_preview_image(msg) == "http://x.com/maybe.png"
+
+
+def test_extract_preview_image_prefers_largest_when_multiple_declared():
+    """Newsletter layout: small logo at top, larger hero below — hero should win."""
+    msg = _make_html_msg(
+        '<header><img src="http://x.com/banner.png" width="180" height="80"></header>'
+        '<article><img src="http://x.com/hero.jpg" width="900" height="600"></article>'
+        '<footer><img src="http://x.com/signature.png" width="200" height="60"></footer>'
+    )
+    assert reader.extract_preview_image(msg) == "http://x.com/hero.jpg"
+
+
+def test_extract_preview_image_skips_logo_filenames():
+    """Images with 'logo' or 'brand' in the filename are skipped regardless of size."""
+    msg = _make_html_msg(
+        '<img src="http://x.com/company-logo.png" width="800" height="200">'
+        '<img src="http://x.com/brand-mark.png" width="800" height="200">'
+        '<img src="http://x.com/hero-content.jpg" width="600" height="400">'
+    )
+    assert reader.extract_preview_image(msg) == "http://x.com/hero-content.jpg"
+
+
+def test_extract_preview_image_skips_masthead_and_sig_filenames():
+    msg = _make_html_msg(
+        '<img src="http://x.com/newsletter-masthead.png" width="800" height="120">'
+        '<img src="http://x.com/sig-author.png" width="300" height="300">'
+        '<img src="http://x.com/article-photo.jpg" width="600" height="400">'
+    )
+    assert reader.extract_preview_image(msg) == "http://x.com/article-photo.jpg"
+
+
+def test_extract_preview_image_falls_back_to_first_when_no_dimensions():
+    """If NO candidate has declared dimensions, we can't pick by area — first wins."""
+    msg = _make_html_msg(
+        '<img src="http://x.com/first.png">'
+        '<img src="http://x.com/second.png">'
+    )
+    assert reader.extract_preview_image(msg) == "http://x.com/first.png"


### PR DESCRIPTION
## Summary

Four fixes on the just-shipped landing page, all from production feedback.

- **Top nav had a 1rem gap above it** — body had `padding: 1rem` which pushed the nav down and kept it from reaching viewport edges. Removed. Pages without wrappers (e.g. `/list`) now get padding via body-direct-child selectors.
- **Brand link went to `/article`** — restructured the left side of the nav: `"email2rss"` → `/` (brand), `"All Articles"` → `/article` (secondary link).
- **Preview extraction picked the newsletter logo, not the content image.** Changed from "first usable" to "largest by area" when multiple images have declared dimensions. Also extended the filename-hint filter to skip branding imagery (`logo`, `brand`, `header-image`, `footer-image`, `masthead`, `sig-`). Fallback to "first image without declared dimensions" preserved for emails that don't declare sizes.
- **Some proxied images 500-ed with no diagnostic.** Added `logger.info` on every `/img` abort path (bad scheme, DNS failure, non-public IP, non-200 upstream, bad content-type, oversize). Production logs will now tell us which URLs fail for which reason.

166 tests green (+4 new extraction tests).

## Test plan

- [ ] CI green
- [ ] Manual `/` — nav is flush against top, brand click goes to `/`, "All Articles" goes to `/article`
- [ ] Manual: inspect preview thumbnails — actual content images, not logos
- [ ] Manual: tail server logs on next broken image to see the specific rejection reason