### PR TITLE
fix: follow redirects in /img proxy + invalidate cached logo URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,7 @@ data/
 
 # database
 *.db
+
+# Local agent/tool state
+.claude/
+.openchrome/

--- a/database.py
+++ b/database.py
@@ -111,6 +111,19 @@ def migrate_database():
         # FTS5 virtual table + delete trigger
         _setup_fts(conn)
 
+        # Schema-version-gated one-shot migrations. PRAGMA user_version is 0 on
+        # fresh DBs and on DBs created before this mechanism existed; each
+        # numbered block bumps it after running so re-runs are no-ops.
+        user_version = conn.execute(text("PRAGMA user_version")).scalar() or 0
+        if user_version < 1:
+            # v1: Invalidate cached preview_image_url values. Rows populated
+            # before the logo-filter + largest-image extractor landed point at
+            # newsletter logos; setting to NULL causes _backfill_preview_images
+            # below to re-extract with the current logic.
+            logging.info("Schema v1: invalidating cached preview_image_url values")
+            conn.execute(text("UPDATE emails SET preview_image_url = NULL"))
+            conn.execute(text("PRAGMA user_version = 1"))
+
         conn.commit()
 
         # Backfill FTS if table is empty but main table has rows (one-time on upgrade)

--- a/img_proxy.py
+++ b/img_proxy.py
@@ -7,7 +7,7 @@ import ipaddress
 import logging
 import socket
 from hashlib import sha256
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -24,6 +24,8 @@ ALLOWED_IMAGE_TYPES = frozenset({
 MAX_IMAGE_BYTES = 5 * 1024 * 1024
 FETCH_TIMEOUT_SECS = 5
 CHUNK_SIZE = 8192
+MAX_REDIRECTS = 3
+REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
 
 
 def _compute_sig(u_param: str, secret: bytes) -> str:
@@ -131,22 +133,22 @@ def _is_public_ip(ip_str: str) -> bool:
     )
 
 
-def fetch_image(url: str, secret: bytes) -> tuple[bytes, str]:
+def _fetch_one_hop(hop_url: str) -> requests.Response:
     """
-    Fetch an image with SSRF defenses. Returns (bytes, content_type) on success,
-    or raises werkzeug HTTPException with the appropriate status code.
+    Apply SSRF validation to `hop_url`, resolve + pin its DNS, and return the
+    streaming response (status not yet inspected).
 
-    `secret` is accepted for API symmetry with sign_url; signature verification
-    happens in the Flask route, not here.
+    Called once per hop in `fetch_image`. Each hop is validated independently so
+    a server-issued redirect cannot escape our SSRF defenses.
     """
-    parsed = urlparse(url)
+    parsed = urlparse(hop_url)
     if parsed.scheme not in ("http", "https"):
-        logger.info("fetch_image reject: bad scheme url=%r", url)
+        logger.info("fetch_image reject: bad scheme url=%r", hop_url)
         abort(400)
 
     host = parsed.hostname
     if not host:
-        logger.info("fetch_image reject: no hostname url=%r", url)
+        logger.info("fetch_image reject: no hostname url=%r", hop_url)
         abort(400)
 
     port = parsed.port or (443 if parsed.scheme == "https" else 80)
@@ -162,7 +164,6 @@ def fetch_image(url: str, secret: bytes) -> tuple[bytes, str]:
         logger.info("fetch_image reject: empty DNS resolution host=%s", host)
         abort(502)
 
-    # Reject if ANY resolved address is non-public
     for ip_str in resolved_ips:
         if not _is_public_ip(ip_str):
             logger.info("fetch_image reject: non-public IP host=%s ip=%s", host, ip_str)
@@ -176,38 +177,71 @@ def fetch_image(url: str, secret: bytes) -> tuple[bytes, str]:
     session.mount("https://", adapter)
 
     try:
-        resp = session.get(
-            url,
+        return session.get(
+            hop_url,
             timeout=FETCH_TIMEOUT_SECS,
             stream=True,
             allow_redirects=False,
             headers={"User-Agent": "email2rss-image-proxy"},
         )
     except requests.RequestException:
-        logger.warning("fetch_image request failed for %s", url)
+        logger.warning("fetch_image request failed for %s", hop_url)
         abort(502)
 
-    try:
-        if resp.status_code != 200:
-            logger.info(
-                "fetch_image reject: upstream status=%s url=%s location=%s",
-                resp.status_code, url, resp.headers.get("Location", ""),
-            )
-            abort(502)
 
-        ctype = (resp.headers.get("Content-Type") or "").split(";")[0].strip().lower()
-        if ctype not in ALLOWED_IMAGE_TYPES:
-            logger.info("fetch_image reject: bad content-type=%r url=%s", ctype, url)
-            abort(415)
+def fetch_image(url: str, secret: bytes) -> tuple[bytes, str]:
+    """
+    Fetch an image with SSRF defenses. Returns (bytes, content_type) on success,
+    or raises werkzeug HTTPException with the appropriate status code.
 
-        body = bytearray()
-        for chunk in resp.iter_content(chunk_size=CHUNK_SIZE):
-            if chunk:
-                body.extend(chunk)
-                if len(body) > MAX_IMAGE_BYTES:
-                    logger.info("fetch_image reject: oversize url=%s", url)
-                    abort(413)
+    Follows up to `MAX_REDIRECTS` hops. Each hop re-runs full SSRF validation
+    (scheme, DNS, public-IP, pinned connect) because a redirect could otherwise
+    point at an internal host.
 
-        return bytes(body), ctype
-    finally:
-        resp.close()
+    `secret` is accepted for API symmetry with sign_url; signature verification
+    happens in the Flask route, not here.
+    """
+    current_url = url
+    for hop in range(MAX_REDIRECTS + 1):
+        resp = _fetch_one_hop(current_url)
+        try:
+            if resp.status_code in REDIRECT_STATUSES:
+                if hop >= MAX_REDIRECTS:
+                    logger.info("fetch_image reject: too many redirects url=%s", url)
+                    abort(502)
+                location = resp.headers.get("Location")
+                if not location:
+                    logger.info(
+                        "fetch_image reject: redirect without Location url=%s status=%s",
+                        current_url, resp.status_code,
+                    )
+                    abort(502)
+                current_url = urljoin(current_url, location)
+                continue
+
+            if resp.status_code != 200:
+                logger.info(
+                    "fetch_image reject: upstream status=%s url=%s",
+                    resp.status_code, current_url,
+                )
+                abort(502)
+
+            ctype = (resp.headers.get("Content-Type") or "").split(";")[0].strip().lower()
+            if ctype not in ALLOWED_IMAGE_TYPES:
+                logger.info("fetch_image reject: bad content-type=%r url=%s", ctype, current_url)
+                abort(415)
+
+            body = bytearray()
+            for chunk in resp.iter_content(chunk_size=CHUNK_SIZE):
+                if chunk:
+                    body.extend(chunk)
+                    if len(body) > MAX_IMAGE_BYTES:
+                        logger.info("fetch_image reject: oversize url=%s", current_url)
+                        abort(413)
+
+            return bytes(body), ctype
+        finally:
+            resp.close()
+
+    # Unreachable: loop either returns or aborts on each iteration.
+    abort(502)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -461,6 +461,66 @@ def test_backfill_preview_images_populates_existing_rows(db_session):
     assert row.preview_image_url == "http://x.com/pic.jpg"
 
 
+def test_migrate_v1_invalidates_and_rebackfills_preview_image_url(db_session):
+    """
+    v1 migration: pre-v1 rows have preview_image_url values cached before the
+    logo-filter + largest-image extractor landed. Running migrate_database()
+    on a user_version=0 DB nulls them, then _backfill_preview_images re-extracts
+    with current logic. user_version bumps to 1.
+    """
+    content = (
+        b"From: s@example.com\r\nSubject: t\r\n"
+        b"MIME-Version: 1.0\r\n"
+        b"Content-Type: text/html; charset=utf-8\r\n\r\n"
+        b'<img src="http://x.com/real-hero.jpg" width="600" height="400">'
+    )
+    db.save_email(
+        sender="s@example.com", receiver="me@localhost", email_id=777,
+        subject="t", content=content, timestamp=datetime.datetime(2026, 4, 13),
+    )
+    # Simulate stale cached logo URL + pre-v1 schema version
+    with db.engine.connect() as conn:
+        conn.execute(text(
+            "UPDATE emails SET preview_image_url = 'http://cdn.x.com/stale-logo.png' "
+            "WHERE email_id = 777"
+        ))
+        conn.execute(text("PRAGMA user_version = 0"))
+        conn.commit()
+
+    db.migrate_database()
+
+    with db.engine.connect() as conn:
+        uv = conn.execute(text("PRAGMA user_version")).scalar()
+    assert uv == 1
+
+    db_session.expire_all()
+    row = db_session.query(db.Email).filter_by(email_id=777).first()
+    assert row.preview_image_url == "http://x.com/real-hero.jpg"
+
+
+def test_migrate_v1_idempotent_when_user_version_is_1(db_session):
+    """Second run of migrate_database must NOT null already-valid preview_image_url."""
+    content = b"From: s@example.com\r\nSubject: t\r\n\r\nbody"
+    db.save_email(
+        sender="s@example.com", receiver="me@localhost", email_id=888,
+        subject="t", content=content, timestamp=datetime.datetime(2026, 4, 13),
+    )
+    # Simulate post-v1 state: set user_version=1 and a specific preview URL
+    with db.engine.connect() as conn:
+        conn.execute(text(
+            "UPDATE emails SET preview_image_url = 'http://keep.me/pic.png' "
+            "WHERE email_id = 888"
+        ))
+        conn.execute(text("PRAGMA user_version = 1"))
+        conn.commit()
+
+    db.migrate_database()
+
+    db_session.expire_all()
+    row = db_session.query(db.Email).filter_by(email_id=888).first()
+    assert row.preview_image_url == "http://keep.me/pic.png"
+
+
 def test_get_landing_data_empty_db(db_session):
     data = db.get_landing_data(latest_limit=10, per_sender_limit=10)
     assert data == {"latest": [], "rows": []}

--- a/tests/test_img_proxy.py
+++ b/tests/test_img_proxy.py
@@ -214,12 +214,97 @@ def test_fetch_image_rejects_oversized(monkeypatch):
 
 
 def test_fetch_image_rejects_non_200(monkeypatch):
+    """404 (and any non-redirect, non-200) → 502."""
     def fake_getaddrinfo(host, port, **kw):
         return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", port))]
     monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
 
     def fake_send(session, req, **kw):
-        return _fake_response(302, {"Location": "http://other/"}, [])
+        return _fake_response(404, {}, [])
+    monkeypatch.setattr("requests.Session.send", fake_send)
+
+    with pytest.raises(HTTPException) as ei:
+        img_proxy.fetch_image("http://example.com/x", TEST_SECRET)
+    assert ei.value.code == 502
+
+
+def test_fetch_image_follows_redirect_to_image(monkeypatch):
+    """302 with valid Location → we re-validate and fetch the target."""
+    def fake_getaddrinfo(host, port, **kw):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", port))]
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    png_body = b"\x89PNG\r\n\x1a\n" + b"\x00" * 50
+    hops = []
+
+    def fake_send(session, req, **kw):
+        hops.append(req.url)
+        if len(hops) == 1:
+            return _fake_response(
+                301, {"Location": "https://cdn.example.com/real.png"}, []
+            )
+        return _fake_response(200, {"Content-Type": "image/png"}, [png_body])
+
+    monkeypatch.setattr("requests.Session.send", fake_send)
+
+    body, ctype = img_proxy.fetch_image(
+        "https://www.google.com/s2/favicons?domain=x.com", TEST_SECRET
+    )
+    assert body == png_body
+    assert ctype == "image/png"
+    assert len(hops) == 2
+
+
+def test_fetch_image_redirect_to_private_ip_rejected(monkeypatch):
+    """Redirect Location resolving to a private IP must be rejected (SSRF via 3xx)."""
+    call_count = {"n": 0}
+
+    def fake_getaddrinfo(host, port, **kw):
+        call_count["n"] += 1
+        # First hop (cdn.example.com) is public; second hop (internal) is private.
+        if call_count["n"] == 1:
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", port))]
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.5", port))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    def fake_send(session, req, **kw):
+        return _fake_response(
+            302, {"Location": "http://internal.corp/secret.png"}, []
+        )
+
+    monkeypatch.setattr("requests.Session.send", fake_send)
+
+    with pytest.raises(HTTPException) as ei:
+        img_proxy.fetch_image("http://cdn.example.com/x.png", TEST_SECRET)
+    assert ei.value.code == 403
+
+
+def test_fetch_image_too_many_redirects(monkeypatch):
+    """Redirect chain longer than MAX_REDIRECTS → 502."""
+    def fake_getaddrinfo(host, port, **kw):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", port))]
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    def fake_send(session, req, **kw):
+        return _fake_response(302, {"Location": "http://example.com/next"}, [])
+
+    monkeypatch.setattr("requests.Session.send", fake_send)
+
+    with pytest.raises(HTTPException) as ei:
+        img_proxy.fetch_image("http://example.com/start", TEST_SECRET)
+    assert ei.value.code == 502
+
+
+def test_fetch_image_redirect_without_location(monkeypatch):
+    """3xx without Location header → 502 (malformed upstream)."""
+    def fake_getaddrinfo(host, port, **kw):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", port))]
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    def fake_send(session, req, **kw):
+        return _fake_response(301, {}, [])
+
     monkeypatch.setattr("requests.Session.send", fake_send)
 
     with pytest.raises(HTTPException) as ei:


### PR DESCRIPTION
## Summary
- **/img redirect-following**: production shows broken favicons because `https://www.google.com/s2/favicons` returns 301 and the proxy rejected any non-200 as 502. Now follows up to 3 hops, re-running full SSRF validation (scheme, DNS all-IP public check, pinned-IP connect) on every hop so a server-side 3xx cannot escape defenses by pointing at an internal host.
- **Logo invalidation**: rows populated before the logo-filter + largest-image extractor landed still cache newsletter logos. Added `PRAGMA user_version` gating in `migrate_database`. When `user_version < 1`, nulls `preview_image_url` and bumps to 1 so the existing backfill re-extracts with current logic. Idempotent.

## Test plan
- [x] 172/172 pytest pass (6 new)
- [x] `test_fetch_image_follows_redirect_to_image` — 301 → image
- [x] `test_fetch_image_redirect_to_private_ip_rejected` — 302 → 10.x rejected (403)
- [x] `test_fetch_image_too_many_redirects` — chain >3 → 502
- [x] `test_fetch_image_redirect_without_location` — 3xx no Location → 502
- [x] `test_migrate_v1_invalidates_and_rebackfills_preview_image_url`
- [x] `test_migrate_v1_idempotent_when_user_version_is_1`
- [ ] Post-merge: verify favicons load on https://email2rss.1kko.com; verify first-card thumbnails change from logos to content images as emails re-backfill

## Notes
- Redirect chase preserves `allow_redirects=False` on the underlying session; the loop is handled in `fetch_image` with a fresh `PinnedIPAdapter` per hop.
- `MAX_REDIRECTS=3` is enough for CDN hops (Google favicons are 1 hop) without letting upstreams pull long chains.