### PR TITLE
chore(deps): bump python-dotenv → 1.2.2 (CVE-2026-28684)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1372,14 +1372,14 @@ six = ">=1.5"
 
 [[package]]
 name = "python-dotenv"
-version = "1.0.1"
+version = "1.2.2"
 description = "Read key-value pairs from a .env file and set them as environment variables"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"},
-    {file = "python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"},
+    {file = "python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a"},
+    {file = "python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3"},
 ]
 
 [package.extras]
@@ -1787,4 +1787,4 @@ test = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "482ef8e273b59ceee4eddb27fa3c8801b09bf6b5e58dec2fd0e33e16dd2f0eee"
+content-hash = "7b0b02628716be8d65e965be567e2beb991335df90bd68753b817ebb77ecf4a1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ version = "0.2.1"
 description = "Add your description here"
 dependencies = [
     "feedgen>=1.0.0",
-    "python-dotenv>=1.0.1",
+    "python-dotenv>=1.2.2",
     "sqlalchemy>=2.0.30",
     "defusedxml>=0.7.1",
     "flask>=3.0,<4.0",
@@ -50,7 +50,7 @@ packages = ["src/email2rss"]
 [tool.poetry.dependencies]
 python = "^3.10"
 feedgen = "^1.0.0"
-python-dotenv = "^1.0.1"
+python-dotenv = "^1.2.2"
 sqlalchemy = "^2.0.30"
 defusedxml = "^0.7.1"
 flask = ">=3.0,<4.0"


### PR DESCRIPTION
## Summary
Patches GHSA-mf9w-mj56-hr94 / CVE-2026-28684 (medium, CVSS 6.6). `set_key()`/`unset_key()` in python-dotenv < 1.2.2 follow symlinks via `shutil.move()`'s cross-device rename fallback, enabling arbitrary file overwrite.

## Exposure here
Low. `common.py:13` calls only `load_dotenv()` (read-only). We never invoke `set_key` or `unset_key`. Bumping anyway to clear the Dependabot alert and cover any future write-side usage.

## Test plan
- [x] `poetry lock` clean
- [x] `poetry install` → updates 1.0.1 → 1.2.2
- [x] 166/166 pytest pass