### PR TITLE
fix(preview): skip banner-shaped images so cards stop repeating mastheads

### DIFF
--- a/database.py
+++ b/database.py
@@ -123,6 +123,13 @@ def migrate_database():
             logging.info("Schema v1: invalidating cached preview_image_url values")
             conn.execute(text("UPDATE emails SET preview_image_url = NULL"))
             conn.execute(text("PRAGMA user_version = 1"))
+        if user_version < 2:
+            # v2: Re-invalidate after adding banner-aspect filter. v1's
+            # largest-image heuristic picked newsletter mastheads (600x100-style
+            # banners) because they outweigh the content hero by area.
+            logging.info("Schema v2: invalidating preview_image_url for banner-aware extraction")
+            conn.execute(text("UPDATE emails SET preview_image_url = NULL"))
+            conn.execute(text("PRAGMA user_version = 2"))
 
         conn.commit()
 

--- a/reader.py
+++ b/reader.py
@@ -273,6 +273,19 @@ def extract_plain_text(msg) -> str:
 _TRACKING_FILENAME_HINTS = ("pixel", "track", "open", "beacon", "spacer")
 _BRAND_FILENAME_HINTS = ("logo", "brand", "header-image", "footer-image", "masthead", "sig-")
 _MIN_IMAGE_PX = 50
+_BANNER_ASPECT_RATIO = 3.5  # width/height above this looks like newsletter masthead
+
+
+def _is_banner_shaped(width: int, height: int) -> bool:
+    """
+    True when width/height > _BANNER_ASPECT_RATIO. Newsletter masthead banners
+    are almost always very wide strips (e.g. 600x100 → 6:1) while real content
+    hero images are ≤ 16:9 (~1.78:1). We only flag wide-and-short; tall images
+    are portrait photos, not banners.
+    """
+    if height <= 0:
+        return False
+    return (width / height) > _BANNER_ASPECT_RATIO
 
 
 def extract_preview_image(msg) -> str | None:
@@ -282,11 +295,14 @@ def extract_preview_image(msg) -> str | None:
 
     Selection strategy:
     1. Collect all <img> candidates that pass the filter rules below.
-    2. If at least one candidate has both width and height declared, return the
-       candidate with the largest area (width × height). This beats the earlier
-       "first-usable" approach that tended to pick the newsletter logo, since
-       logos are usually near the top and smaller than the article's hero image.
-    3. If no candidate has declared dimensions, return the first one (best we
+    2. Among candidates with declared dimensions, prefer non-banner-shaped ones
+       (width/height ≤ _BANNER_ASPECT_RATIO). Banner-shaped images are template
+       mastheads repeated across every email from a sender — they produce
+       identical thumbnails for every article. If any non-banner candidate
+       exists, return the largest by area.
+    3. If every candidate is banner-shaped, fall back to the largest of those
+       (better than no image).
+    4. If no candidate has declared dimensions, return the first one (best we
        can do without rendering the email to measure images).
 
     Filter rules (each applies before a candidate is considered):
@@ -304,7 +320,8 @@ def extract_preview_image(msg) -> str | None:
     if not body_html:
         return None
 
-    candidates: list[tuple[int, str]] = []  # (area, src); area=-1 when unknown
+    # (area, width, height, src) — width/height retained for aspect-ratio test
+    candidates: list[tuple[int, int, int, str]] = []
     first_unknown_area: str | None = None
 
     for match in re.finditer(r'<img\b([^>]*)>', body_html, flags=re.IGNORECASE):
@@ -341,16 +358,17 @@ def extract_preview_image(msg) -> str | None:
         if width is not None and height is not None:
             if width < _MIN_IMAGE_PX or height < _MIN_IMAGE_PX:
                 continue
-            candidates.append((width * height, src))
+            candidates.append((width * height, width, height, src))
         else:
             # No declared dimensions — remember the first so we can fall back
             if first_unknown_area is None:
                 first_unknown_area = src
 
-    # Prefer the largest declared candidate
     if candidates:
-        candidates.sort(key=lambda c: c[0], reverse=True)
-        return candidates[0][1]
+        non_banner = [c for c in candidates if not _is_banner_shaped(c[1], c[2])]
+        pool = non_banner if non_banner else candidates
+        pool.sort(key=lambda c: c[0], reverse=True)
+        return pool[0][3]
 
     # Fallback: first image with unknown dimensions
     return first_unknown_area

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -461,12 +461,11 @@ def test_backfill_preview_images_populates_existing_rows(db_session):
     assert row.preview_image_url == "http://x.com/pic.jpg"
 
 
-def test_migrate_v1_invalidates_and_rebackfills_preview_image_url(db_session):
+def test_migrate_from_v0_runs_all_invalidations_and_bumps_to_current(db_session):
     """
-    v1 migration: pre-v1 rows have preview_image_url values cached before the
-    logo-filter + largest-image extractor landed. Running migrate_database()
-    on a user_version=0 DB nulls them, then _backfill_preview_images re-extracts
-    with current logic. user_version bumps to 1.
+    Fresh/pre-mechanism DBs have user_version=0. migrate_database() runs every
+    version-gated block in order (v1, v2, ...) and bumps to the latest schema
+    version. Cached preview URLs are re-extracted with the current logic.
     """
     content = (
         b"From: s@example.com\r\nSubject: t\r\n"
@@ -478,10 +477,10 @@ def test_migrate_v1_invalidates_and_rebackfills_preview_image_url(db_session):
         sender="s@example.com", receiver="me@localhost", email_id=777,
         subject="t", content=content, timestamp=datetime.datetime(2026, 4, 13),
     )
-    # Simulate stale cached logo URL + pre-v1 schema version
+    # Simulate stale cached value + pre-migration-mechanism schema version
     with db.engine.connect() as conn:
         conn.execute(text(
-            "UPDATE emails SET preview_image_url = 'http://cdn.x.com/stale-logo.png' "
+            "UPDATE emails SET preview_image_url = 'http://cdn.x.com/stale.png' "
             "WHERE email_id = 777"
         ))
         conn.execute(text("PRAGMA user_version = 0"))
@@ -491,27 +490,28 @@ def test_migrate_v1_invalidates_and_rebackfills_preview_image_url(db_session):
 
     with db.engine.connect() as conn:
         uv = conn.execute(text("PRAGMA user_version")).scalar()
-    assert uv == 1
+    assert uv == 2  # current schema version
 
     db_session.expire_all()
     row = db_session.query(db.Email).filter_by(email_id=777).first()
     assert row.preview_image_url == "http://x.com/real-hero.jpg"
 
 
-def test_migrate_v1_idempotent_when_user_version_is_1(db_session):
-    """Second run of migrate_database must NOT null already-valid preview_image_url."""
+def test_migrate_idempotent_at_current_schema_version(db_session):
+    """Second run of migrate_database must NOT null preview_image_url once user_version
+    is at the current schema level — all version-gated blocks are no-ops."""
     content = b"From: s@example.com\r\nSubject: t\r\n\r\nbody"
     db.save_email(
         sender="s@example.com", receiver="me@localhost", email_id=888,
         subject="t", content=content, timestamp=datetime.datetime(2026, 4, 13),
     )
-    # Simulate post-v1 state: set user_version=1 and a specific preview URL
+    # Simulate fully-migrated state: user_version=2 (current) + a specific URL
     with db.engine.connect() as conn:
         conn.execute(text(
             "UPDATE emails SET preview_image_url = 'http://keep.me/pic.png' "
             "WHERE email_id = 888"
         ))
-        conn.execute(text("PRAGMA user_version = 1"))
+        conn.execute(text("PRAGMA user_version = 2"))
         conn.commit()
 
     db.migrate_database()
@@ -519,6 +519,44 @@ def test_migrate_v1_idempotent_when_user_version_is_1(db_session):
     db_session.expire_all()
     row = db_session.query(db.Email).filter_by(email_id=888).first()
     assert row.preview_image_url == "http://keep.me/pic.png"
+
+
+def test_migrate_v2_reinvalidates_from_v1(db_session):
+    """
+    v1 users have preview URLs picked by largest-image (which chose banners).
+    Upgrading user_version=1 → 2 nulls the column so the banner-aware extractor
+    re-runs via _backfill_preview_images.
+    """
+    content = (
+        b"From: s@example.com\r\nSubject: t\r\n"
+        b"MIME-Version: 1.0\r\n"
+        b"Content-Type: text/html; charset=utf-8\r\n\r\n"
+        b'<img src="http://x.com/masthead.png" width="600" height="100">'
+        b'<img src="http://x.com/hero.jpg" width="500" height="350">'
+    )
+    db.save_email(
+        sender="s@example.com", receiver="me@localhost", email_id=999,
+        subject="t", content=content, timestamp=datetime.datetime(2026, 4, 13),
+    )
+    # Simulate post-v1 state: banner URL cached, user_version=1
+    with db.engine.connect() as conn:
+        conn.execute(text(
+            "UPDATE emails SET preview_image_url = 'http://x.com/masthead.png' "
+            "WHERE email_id = 999"
+        ))
+        conn.execute(text("PRAGMA user_version = 1"))
+        conn.commit()
+
+    db.migrate_database()
+
+    with db.engine.connect() as conn:
+        uv = conn.execute(text("PRAGMA user_version")).scalar()
+    assert uv == 2
+
+    db_session.expire_all()
+    row = db_session.query(db.Email).filter_by(email_id=999).first()
+    # Banner-aware extractor prefers hero over the banner-shaped masthead
+    assert row.preview_image_url == "http://x.com/hero.jpg"
 
 
 def test_get_landing_data_empty_db(db_session):

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -352,3 +352,39 @@ def test_extract_preview_image_falls_back_to_first_when_no_dimensions():
         '<img src="http://x.com/second.png">'
     )
     assert reader.extract_preview_image(msg) == "http://x.com/first.png"
+
+
+def test_extract_preview_image_skips_banner_shaped_when_hero_exists():
+    """Newsletter masthead (600x100, 6:1) is wider than 3.5:1 → skip in favor of hero."""
+    msg = _make_html_msg(
+        '<img src="http://x.com/masthead.png" width="600" height="100">'
+        '<img src="http://x.com/hero.jpg" width="500" height="350">'
+    )
+    # Masthead has larger area (60000) but banner-shaped; hero wins.
+    assert reader.extract_preview_image(msg) == "http://x.com/hero.jpg"
+
+
+def test_extract_preview_image_falls_back_to_banner_when_its_the_only_option():
+    """If every candidate is banner-shaped, take the largest banner — better than None."""
+    msg = _make_html_msg(
+        '<img src="http://x.com/banner-a.png" width="600" height="100">'
+        '<img src="http://x.com/banner-b.png" width="800" height="120">'
+    )
+    assert reader.extract_preview_image(msg) == "http://x.com/banner-b.png"
+
+
+def test_extract_preview_image_does_not_flag_moderately_wide_content():
+    """4:3 or 16:9 hero (≤ 3.5:1) is NOT a banner — must still win over a small image."""
+    msg = _make_html_msg(
+        '<img src="http://x.com/thumb.jpg" width="100" height="100">'
+        '<img src="http://x.com/wide-hero.jpg" width="1600" height="900">'  # 16:9 ≈ 1.78
+    )
+    assert reader.extract_preview_image(msg) == "http://x.com/wide-hero.jpg"
+
+
+def test_extract_preview_image_does_not_flag_tall_images_as_banner():
+    """Tall portrait (1:3) should NOT be treated as banner — ratio test is one-sided."""
+    msg = _make_html_msg(
+        '<img src="http://x.com/portrait.jpg" width="400" height="1200">'
+    )
+    assert reader.extract_preview_image(msg) == "http://x.com/portrait.jpg"


### PR DESCRIPTION
## Summary
Production landing rows showed the **same thumbnail on every card** from a given sender. The largest-by-area extractor was selecting the newsletter's masthead banner (600x100-style template image), which is identical across every edition → identical cards.

Added an aspect-ratio guard: when `width/height > 3.5` the image is banner-shaped. Among candidates we prefer non-banner-shaped, falling back to banner-shaped only when nothing else exists.

Bumped `PRAGMA user_version` to 2 with a one-shot re-invalidation of `preview_image_url` so the existing backfill re-extracts with the new logic across already-stored rows.

## Test plan
- [x] 177/177 pytest pass (5 new)
- [x] `test_extract_preview_image_skips_banner_shaped_when_hero_exists` — 600x100 masthead loses to 500x350 hero even though masthead has higher area
- [x] `test_extract_preview_image_falls_back_to_banner_when_its_the_only_option` — single banner still returned (better than None)
- [x] `test_extract_preview_image_does_not_flag_moderately_wide_content` — 16:9 hero (1.78:1) not flagged
- [x] `test_extract_preview_image_does_not_flag_tall_images_as_banner` — 1:3 portrait not flagged (one-sided ratio)
- [x] `test_migrate_v2_reinvalidates_from_v1` — user_version 1 → 2 re-runs backfill
- [ ] Post-merge: verify landing cards show distinct content images per article instead of repeating the sender's banner

## Notes
- Threshold `3.5` chosen because typical newsletter banners are ≥ 6:1 (600x100) while content heroes are ≤ 16:9 (~1.78:1) — `3.5` sits safely between them so wide-but-legitimate content (e.g. 3:1 cinematic photos) is still accepted.
- The aspect test is one-sided (wide, not tall). Portrait photos are not banners.