### PR TITLE
fix(img): prefer IPv4 when DNS returns both families (favicon 502 root cause)

### DIFF
--- a/img_proxy.py
+++ b/img_proxy.py
@@ -159,7 +159,12 @@ def _fetch_one_hop(hop_url: str) -> requests.Response:
         logger.info("fetch_image reject: DNS failure host=%s err=%s", host, e)
         abort(502)
 
-    resolved_ips = {info[4][0] for info in infos}
+    # Split by family and prefer IPv4. Many container runtimes have IPv4-only
+    # egress; picking an IPv6 address there silently fails TCP connect → 502.
+    # Using sorted() also gives deterministic pinning for logs and tests.
+    ipv4s = sorted({info[4][0] for info in infos if info[0] == socket.AF_INET})
+    ipv6s = sorted({info[4][0] for info in infos if info[0] == socket.AF_INET6})
+    resolved_ips = ipv4s + ipv6s
     if not resolved_ips:
         logger.info("fetch_image reject: empty DNS resolution host=%s", host)
         abort(502)
@@ -169,7 +174,7 @@ def _fetch_one_hop(hop_url: str) -> requests.Response:
             logger.info("fetch_image reject: non-public IP host=%s ip=%s", host, ip_str)
             abort(403)
 
-    pinned_ip = next(iter(resolved_ips))
+    pinned_ip = resolved_ips[0]
 
     session = requests.Session()
     adapter = PinnedIPAdapter(pinned_host=host, pinned_ip=pinned_ip)

--- a/tests/test_img_proxy.py
+++ b/tests/test_img_proxy.py
@@ -148,6 +148,32 @@ def _fake_response(status, headers, body_chunks):
     return R()
 
 
+def test_fetch_image_prefers_ipv4_when_both_families_resolved(monkeypatch):
+    """Many container runtimes have IPv4-only egress; picking IPv6 from a
+    dual-stack DNS result would silently fail TCP connect → 502. The pinned
+    IP must be the IPv4 address."""
+    def fake_getaddrinfo(host, port, **kw):
+        return [
+            (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("2001:4860::1", port, 0, 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("142.251.156.119", port)),
+        ]
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    captured_urls = []
+
+    def fake_send(adapter, req, **kw):
+        captured_urls.append(req.url)
+        return _fake_response(200, {"Content-Type": "image/png"}, [b"\x89PNG"])
+
+    monkeypatch.setattr("requests.adapters.HTTPAdapter.send", fake_send)
+
+    body, ctype = img_proxy.fetch_image("http://dualstack.example.com/x.png", TEST_SECRET)
+    assert ctype == "image/png"
+    # URL was rewritten to the IPv4 address, not the IPv6 one
+    assert "142.251.156.119" in captured_urls[0]
+    assert "2001:4860" not in captured_urls[0]
+
+
 def test_fetch_image_happy_path_png(monkeypatch):
     def fake_getaddrinfo(host, port, **kw):
         return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", port))]


### PR DESCRIPTION
## Summary
After PR #19 shipped, Google favicons still returned 502 on prod while other images worked. Verified locally with debug logging:
\`\`\`
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): 2001:4860:4826:7700::
WARNING:img_proxy:fetch_image request failed for https://www.google.com/s2/favicons?domain=booding.co&sz=128
\`\`\`

Root cause: `getaddrinfo` returns both IPv4 and IPv6 for `www.google.com`. The proxy collected IPs into a **set** and picked one via `next(iter(...))`, which is non-deterministic. When the IPv6 address was chosen and the container had IPv4-only egress, TCP connect failed silently → 502 — PR #19's redirect-following code never got to run.

Fix: split DNS results by family, prefer IPv4, fall back to IPv6 only if no IPv4 exists. Public-IP validation still runs on the full set. Pinning is now deterministic.

## Test plan
- [x] 178/178 pytest pass (1 new)
- [x] `test_fetch_image_prefers_ipv4_when_both_families_resolved` — asserts rewritten URL uses IPv4 when both families returned
- [x] Local reproduction: `fetch_image("https://www.google.com/s2/favicons?domain=booding.co&sz=128")` now returns 1586-byte JPEG (via Google→gstatic redirect)
- [ ] Post-merge: favicons load on https://email2rss.1kko.com