### PR TITLE
feat(reader): force dark mode in iframe via invert filter

### DIFF
--- a/reader.py
+++ b/reader.py
@@ -242,7 +242,17 @@ body {{ font: 16px/1.5 -apple-system, system-ui, sans-serif; color: #222; margin
 img {{ max-width: 100%; height: auto; animation: fade-in 0.3s ease-out; }}
 @keyframes fade-in {{ from {{ opacity: 0; }} to {{ opacity: 1; }} }}
 a {{ color: #0066cc; }}
-@media (prefers-color-scheme: dark) {{ body {{ background: #1a1a1a; color: #eee; }} }}
+@media (prefers-color-scheme: dark) {{
+  /* Inline styles inside newsletter HTML (bgcolor="#fff", color:#000, etc.)
+     win over our CSS via specificity, so the @media rule on body was only
+     re-skinning the margin strip. Apply an invert+hue-rotate filter to the
+     whole document so every painted color flips to its dark-mode equivalent.
+     Images/SVG/video get an inverse filter that cancels the outer one so
+     they render with their original colors — photos, logos, charts stay
+     correct. */
+  html {{ background: #1a1a1a; filter: invert(1) hue-rotate(180deg); }}
+  img, svg, picture, video, canvas {{ filter: invert(1) hue-rotate(180deg); }}
+}}
 </style>
 </head>
 <body>{body}</body>

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -245,6 +245,19 @@ def test_render_iframe_document_includes_csp_and_body():
     assert "<p>hi</p>" in doc
 
 
+def test_render_iframe_document_forces_dark_mode_via_filter():
+    """
+    In dark mode we invert the html filter so inline email styles (bgcolor=#fff,
+    color:#000) flip to dark. Images/SVG/video get a canceling inverse filter
+    so photos and logos render with their true colors.
+    """
+    doc = reader.render_iframe_document("<p>hi</p>", proxy_origin="http://localhost:8000")
+    assert "@media (prefers-color-scheme: dark)" in doc
+    assert "filter: invert(1) hue-rotate(180deg)" in doc
+    # Verify media elements get their own filter rule for cancellation
+    assert "img, svg, picture, video, canvas" in doc
+
+
 def _make_html_msg(html_body: str, sender="s@example.com"):
     """Build a simple text/html MIME message for tests."""
     import email as email_mod


### PR DESCRIPTION
## Summary
Newsletter HTML carries heavy inline styles (\`bgcolor=\"#fff\"\`, \`color:#000\`) that beat our \`@media\` CSS on specificity. In OS dark mode the article body rendered as black-on-near-black, effectively unreadable (reported on https://email2rss.1kko.com/article/miraklelab_mk_co_kr/...).

Apply \`invert(1) hue-rotate(180deg)\` to the iframe's \`html\` element when \`prefers-color-scheme: dark\` matches. That flips every painted color — inline or CSS — to its dark-mode counterpart. Images, SVG, picture, video, and canvas get the same filter so the double-inversion cancels out and they render with their original colors.

## Tradeoffs (transparent)
- Pros: readable text on dark backgrounds without guessing each newsletter's markup
- Cons: colored backgrounds that are ONLY set via CSS \`background-image: linear-gradient(...)\` aren't images, so they invert; most newsletters use flat \`bgcolor\` attrs so this is rare
- Brand colors (e.g. the red "MIRAKLE" in the reported article) stay intact because they're painted by an image

## Test plan
- [x] 179/179 pytest pass (1 new)
- [x] \`test_render_iframe_document_forces_dark_mode_via_filter\` — asserts media query + invert filter + canceling filter on img/svg/video/canvas
- [ ] Post-merge: visual check of miraklelab article in OS dark mode — body text readable, banner image unchanged