### PR TITLE
fix(ui): landing divider, iframe autosize, centering, bfcache unread, nav

### DIFF
--- a/reader.py
+++ b/reader.py
@@ -239,6 +239,12 @@ _IFRAME_TEMPLATE = """\
 <base target="_blank">
 <style>
 body {{ font: 16px/1.5 -apple-system, system-ui, sans-serif; color: #222; margin: 0 1rem; }}
+/* Center block-level email content. Newsletter templates commonly use
+   fixed-width tables (e.g. width:600px) laid out flush-left; `margin: 0 auto`
+   centers them within the iframe viewport. Content without a fixed width
+   still fills naturally because auto margins only collapse when a width
+   is declared. */
+body > * {{ margin-left: auto; margin-right: auto; }}
 img {{ max-width: 100%; height: auto; animation: fade-in 0.3s ease-out; }}
 @keyframes fade-in {{ from {{ opacity: 0; }} to {{ opacity: 1; }} }}
 a {{ color: #0066cc; }}

--- a/static/reader.css
+++ b/static/reader.css
@@ -3,7 +3,7 @@
     --bg-color: #ffffff;
     --text-color: #333333;
     --meta-color: #666666;
-    --border-color: #e0e0e000;
+    --border-color: #e0e0e0;
     --link-color: #0066cc;
     --code-bg: #f5f5f5;
     --card-bg: #ffffff;
@@ -15,7 +15,7 @@
         --bg-color: #1a1a1a;
         --text-color: #e0e0e0;
         --meta-color: #a0a0a0;
-        --border-color: #33333300;
+        --border-color: #333;
         --link-color: #4da6ff;
         --code-bg: #2a2a2a;
         --card-bg: #1e1e1e;
@@ -165,10 +165,12 @@ h1 {
 
 .email-body-iframe {
   width: 100%;
-  /* Fill viewport below the site nav + article header. Falls back to 80vh
-     on browsers that don't support calc-with-vh (rare). */
-  height: calc(100vh - 180px);
-  min-height: 60vh;
+  /* Height is set dynamically by reader.js to the iframe content's scrollHeight
+     so the article reads as a single continuous page — no nested scrollbar.
+     We seed with a small initial value; JS kicks in on load and on every image
+     load event. Falls back gracefully if JS is disabled (page just scrolls
+     inside the iframe at a sensible size). */
+  height: 80vh;
   border: 0;
   display: block;
   background: transparent;
@@ -183,6 +185,11 @@ h1 {
   padding: 0.75rem 1rem;
   border-bottom: 1px solid #e0e0e0;
   background: #fafafa;
+  /* Sticky so the nav stays visible while the article scrolls, matching the
+     landing page behavior and the original Netflix-style mockup. */
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
 .site-nav__left {
   display: flex;

--- a/static/reader.js
+++ b/static/reader.js
@@ -58,6 +58,70 @@ document.addEventListener('DOMContentLoaded', () => {
       window.location.href = '/article';
     });
   }
+
+  // Auto-size the email iframe to its content so the page reads as one
+  // continuous scroll (no nested scrollbar). Requires allow-same-origin in
+  // the iframe sandbox — safe because the inner CSP still forbids scripts,
+  // so the iframe can't run JS to exploit same-origin access.
+  const iframe = document.getElementById('email-body');
+  if (iframe) {
+    const resize = () => {
+      try {
+        const doc = iframe.contentDocument;
+        if (!doc) return;
+        const h = Math.max(
+          doc.documentElement.scrollHeight,
+          doc.body ? doc.body.scrollHeight : 0
+        );
+        if (h > 0) iframe.style.height = h + 'px';
+      } catch (_) { /* cross-origin or not loaded yet */ }
+    };
+    iframe.addEventListener('load', () => {
+      resize();
+      try {
+        const ro = new ResizeObserver(resize);
+        if (iframe.contentDocument?.body) ro.observe(iframe.contentDocument.body);
+      } catch (_) { /* ResizeObserver unsupported — fall back to image-load hook */ }
+      iframe.contentDocument?.querySelectorAll('img').forEach((img) => {
+        if (!img.complete) img.addEventListener('load', resize);
+      });
+    });
+  }
+});
+
+// --- Unread-dot optimistic update ---
+// When the user clicks a card, note its href in sessionStorage. On pageshow
+// (including bfcache restore, which hands back the stale landing DOM),
+// strip the unread dot from any card whose href matches a visited entry.
+// Dwell-timer on the article page still does the server-side mark_read; this
+// is purely a UI sync for the "browser back" path where the stale page would
+// otherwise still show the blue dot until a hard refresh.
+const VISITED_KEY = 'email2rss.visitedArticles';
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.article-card[href]').forEach((card) => {
+    card.addEventListener('click', () => {
+      try {
+        const visited = JSON.parse(sessionStorage.getItem(VISITED_KEY) || '[]');
+        if (!visited.includes(card.getAttribute('href'))) {
+          visited.push(card.getAttribute('href'));
+          sessionStorage.setItem(VISITED_KEY, JSON.stringify(visited));
+        }
+      } catch (_) { /* sessionStorage unavailable — dwell timer + refresh still works */ }
+    });
+  });
+});
+window.addEventListener('pageshow', () => {
+  try {
+    const visited = JSON.parse(sessionStorage.getItem(VISITED_KEY) || '[]');
+    if (!visited.length) return;
+    const hrefs = new Set(visited);
+    document.querySelectorAll('.article-card[href]').forEach((card) => {
+      if (hrefs.has(card.getAttribute('href'))) {
+        const dot = card.querySelector('.article-card__unread-dot');
+        if (dot) dot.remove();
+      }
+    });
+  } catch (_) { /* ignore — stale DOM still readable */ }
 });
 
 // --- Landing page scroller wiring (Netflix-style horizontal rows) ---

--- a/templates/article.html
+++ b/templates/article.html
@@ -20,7 +20,7 @@
   <iframe
     id="email-body"
     class="email-body-iframe"
-    sandbox="allow-popups allow-popups-to-escape-sandbox"
+    sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin"
     srcdoc="{{ iframe_document|e }}"
     referrerpolicy="no-referrer"
     loading="lazy"

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,7 @@
     <div class="site-nav__left">
       <a href="/" class="nav-home" aria-label="email2rss home">email2rss</a>
       <a href="/article" class="nav-link">All Articles</a>
+      <a href="/list" class="nav-link">Raw Feeds</a>
     </div>
     <form class="nav-search" action="/search" method="get">
       <input type="search" name="q" placeholder="Search..." value="{{ search_q or '' }}" required>

--- a/tests/test_feed_server.py
+++ b/tests/test_feed_server.py
@@ -89,7 +89,9 @@ def test_article_route_renders_body_in_sandboxed_iframe(client, db_session, monk
     assert resp.status_code == 200
     html = resp.data.decode("utf-8")
     assert '<iframe' in html
-    assert 'sandbox="allow-popups allow-popups-to-escape-sandbox"' in html
+    # allow-same-origin enables parent JS to auto-size the iframe to its
+    # content; safe because the inner CSP blocks scripts from running.
+    assert 'sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin"' in html
     assert 'srcdoc=' in html
     assert "Hello from the test suite" in html  # subject in header
 


### PR DESCRIPTION
## Summary
Six UI polish items from live testing:

1. **Fix transparent border-color** — `--border-color` was `#e0e0e000` (8-hex with alpha=00). Restored to `#e0e0e0` / `#333`. Restores the divider under `.latest-section` (mockup-style separation between Latest and per-sender rows) and every other border that used the var.
2. **Iframe auto-sizes to content** — article page had page-scroll + iframe-scroll (double scroll). Added `allow-same-origin` to the iframe sandbox (still no \`allow-scripts\` + strict inner CSP, so the iframe can't run JS), and a \`ResizeObserver\` in \`reader.js\` that sets \`iframe.style.height\` to the content's \`scrollHeight\`. Hooks image loads too so late-arriving images re-fit.
3. **"Raw Feeds" nav link** → \`/list\`.
4. **Center left-aligned articles** — fixed-width newsletter tables (typical 600px stibee/themiilk designs) center via \`body > * { margin: 0 auto }\` in the iframe template.
5. **Unread-dot optimistic update** — on card click, save guid to \`sessionStorage\`; on \`pageshow\` (covers bfcache restore) strip \`.article-card__unread-dot\` from matching cards. No hard-refresh needed after browser back.
6. **Sticky nav** — \`.site-nav\` is \`position: sticky; top: 0\`, matching the Netflix-style mockup and keeping the nav visible during article scroll.

## Security note
\`allow-same-origin\` sounds scary but the iframe still has \`default-src 'none'\` via inner CSP and no \`allow-scripts\` in its sandbox — the iframe cannot execute any JS, so it cannot exploit the same-origin access to touch the parent. The only thing \`allow-same-origin\` unlocks is the parent being able to *read* the iframe's \`contentDocument\`, which is exactly what we need for auto-sizing.

## Test plan
- [x] 179/179 pytest pass (updated sandbox-assertion test)
- [ ] Post-merge: article page reads as single scroll, viewsletter/themiilk content centered, landing cards have visible divider after Latest, click→back keeps unread dots cleared, nav stays at top while scrolling