### PR TITLE
fix(reader): hide iframe scrollbar during load

### DIFF
--- a/reader.py
+++ b/reader.py
@@ -239,6 +239,14 @@ _IFRAME_TEMPLATE = """\
 <base target="_blank">
 <style>
 body {{ font: 16px/1.5 -apple-system, system-ui, sans-serif; color: #222; margin: 0 1rem; }}
+/* Hide the iframe's own scrollbar — parent JS auto-sizes the iframe to its
+   content height, so the outer page is the one that scrolls. Without this,
+   long emails flash an inner scrollbar during load until ResizeObserver
+   fires and grows the iframe. Purely cosmetic; content is not clipped. */
+html {{ scrollbar-width: none; }}
+html::-webkit-scrollbar {{ display: none; }}
+body {{ scrollbar-width: none; }}
+body::-webkit-scrollbar {{ display: none; }}
 /* Center block-level email content. Newsletter templates commonly use
    fixed-width tables (e.g. width:600px) laid out flush-left; `margin: 0 auto`
    centers them within the iframe viewport. Content without a fixed width


### PR DESCRIPTION
## Summary
Long emails briefly flashed a scrollbar inside the iframe before the ResizeObserver fired and auto-sized the iframe. Cosmetic only but visible.

Hide the iframe's own scrollbar with \`scrollbar-width: none\` + \`::-webkit-scrollbar { display: none }\`. The outer page is the one that scrolls (matches the intent of the iframe auto-resize), so the inner scrollbar is redundant once JS runs. Content is never clipped — \`overflow\` stays default.

## Test plan
- [x] 42/42 reader tests pass
- [ ] Post-merge: reload a long article (e.g. miraklelab), no scrollbar flash during load