### PR TITLE
feat(ui): rewire nav, starred filter, back link, strip dark bg

### DIFF
--- a/database.py
+++ b/database.py
@@ -710,8 +710,15 @@ def _article_dict(row: Email, sign_url) -> dict:
     }
 
 
-def get_landing_data(latest_limit: int = 10, per_sender_limit: int = 10) -> dict:
-    """Return the landing-page payload. See spec for shape details."""
+def get_landing_data(
+    latest_limit: int = 10, per_sender_limit: int = 10, starred_only: bool = False
+) -> dict:
+    """
+    Return the landing-page payload.
+
+    When `starred_only` is True, both the Latest strip and per-sender rows
+    include only rows where is_starred=True. Empty rows are omitted.
+    """
     from common import get_img_proxy_secret, config
     import img_proxy
 
@@ -725,33 +732,33 @@ def get_landing_data(latest_limit: int = 10, per_sender_limit: int = 10) -> dict
 
     with Session() as session:
         # Latest across all senders
-        latest_rows = (
-            session.query(Email)
-            .order_by(Email.timestamp.desc())
-            .limit(latest_limit)
-            .all()
-        )
+        latest_q = session.query(Email)
+        if starred_only:
+            latest_q = latest_q.filter(Email.is_starred == True)  # noqa: E712
+        latest_rows = latest_q.order_by(Email.timestamp.desc()).limit(latest_limit).all()
         latest = [_article_dict(r, sign) for r in latest_rows]
 
         # Per-sender: get each sender's most recent timestamp (for row ordering)
         from sqlalchemy import func
-        sender_tops = (
-            session.query(Email.sender, func.max(Email.timestamp).label("t_max"),
-                          func.count(Email.id).label("article_count"))
-            .group_by(Email.sender)
-            .order_by(func.max(Email.timestamp).desc())
-            .all()
+        sender_tops_q = session.query(
+            Email.sender,
+            func.max(Email.timestamp).label("t_max"),
+            func.count(Email.id).label("article_count"),
         )
+        if starred_only:
+            sender_tops_q = sender_tops_q.filter(Email.is_starred == True)  # noqa: E712
+        sender_tops = sender_tops_q.group_by(Email.sender).order_by(
+            func.max(Email.timestamp).desc()
+        ).all()
 
         rows = []
         for sender, _t_max, article_count in sender_tops:
-            sender_articles = (
-                session.query(Email)
-                .filter_by(sender=sender)
-                .order_by(Email.timestamp.desc())
-                .limit(per_sender_limit)
-                .all()
-            )
+            articles_q = session.query(Email).filter_by(sender=sender)
+            if starred_only:
+                articles_q = articles_q.filter(Email.is_starred == True)  # noqa: E712
+            sender_articles = articles_q.order_by(Email.timestamp.desc()).limit(
+                per_sender_limit
+            ).all()
             if not sender_articles:
                 continue
             dicts = [_article_dict(r, sign) for r in sender_articles]

--- a/feed_server.py
+++ b/feed_server.py
@@ -78,34 +78,6 @@ def create_app() -> Flask:
             "senders": senders,
         })
 
-    @app.get("/article")
-    def article_list():
-        filter_mode = request.args.get("filter", "all")
-        if filter_mode not in ("all", "unread", "starred"):
-            abort(400)
-        articles = db.get_emails_filtered(
-            sender=None, filter_mode=filter_mode, limit=config.get("max_item_per_feed", 100) * 10
-        )
-        # Group by sender for the sidebar
-        senders: dict = {}
-        for article in articles:
-            s = article["sender"]
-            if s not in senders:
-                senders[s] = {"count": 0, "latest": article["timestamp"], "feed_name": article["feed_name"]}
-            senders[s]["count"] += 1
-            if article["timestamp"] > senders[s]["latest"]:
-                senders[s]["latest"] = article["timestamp"]
-        sorted_senders = sorted(senders.items(), key=lambda x: x[1]["latest"], reverse=True)
-
-        return render_template(
-            "article_list.html",
-            page_title="All Articles",
-            articles=articles,
-            senders=sorted_senders,
-            specific_sender=None,
-            filter_mode=filter_mode,
-        )
-
     @app.get("/article/<feed_name>")
     def feed_article_list(feed_name):
         sender_email = feed_name_to_email(feed_name)
@@ -243,8 +215,11 @@ def create_app() -> Flask:
     def home():
         # Landing-page limits are fixed. max_item_per_feed (default 100) drives
         # RSS XML feed size, a separate concern.
-        data = db.get_landing_data(latest_limit=10, per_sender_limit=10)
-        return render_template("index.html", data=data)
+        starred_only = request.args.get("starred") == "1"
+        data = db.get_landing_data(
+            latest_limit=10, per_sender_limit=10, starred_only=starred_only
+        )
+        return render_template("index.html", data=data, starred_only=starred_only)
 
     @app.get("/list")
     def xml_file_list():

--- a/reader.py
+++ b/reader.py
@@ -257,17 +257,22 @@ img {{ max-width: 100%; height: auto; animation: fade-in 0.3s ease-out; }}
 @keyframes fade-in {{ from {{ opacity: 0; }} to {{ opacity: 1; }} }}
 a {{ color: #0066cc; }}
 @media (prefers-color-scheme: dark) {{
-  /* Invert+hue-rotate so inline email styles (color:#000, transparent bg +
-     dark text, etc.) flip to their dark-mode counterparts. Our own
-     declarations must be "pre-inverted": html painted as #e5e5e5 renders
-     as #1a1a1a to the viewer after the filter runs. Setting html to
-     #1a1a1a directly would leave the viewer seeing #e5e5e5 — a light
-     surface where dark inline text (#212121 → #dedede) sits, making the
-     content invisible.
-     Images/SVG/video/canvas get a canceling inverse filter so photos,
-     logos, and charts render with their original colors. */
-  html {{ background: #e5e5e5; filter: invert(1) hue-rotate(180deg); }}
-  img, svg, picture, video, canvas {{ filter: invert(1) hue-rotate(180deg); }}
+  /* Strip every explicit background inside the email so content blends into
+     our dark canvas — visually more unified than an inverted "card". Images,
+     SVG, video, and canvas keep their own rendering so brand imagery stays
+     correct. Text colors get forced to a readable light value because many
+     newsletters hard-code dark text (e.g. color:#212121) that would vanish
+     on a dark background if we only stripped the bg. Links keep a
+     distinguishable blue. */
+  html, body {{ background: #1a1a1a; color: #e5e5e5; }}
+  body *:not(img):not(svg):not(picture):not(video):not(canvas) {{
+    background-color: transparent !important;
+    background-image: none !important;
+  }}
+  body, body *:not(a):not(img):not(svg):not(picture):not(video):not(canvas) {{
+    color: #e5e5e5 !important;
+  }}
+  body a, body a * {{ color: #4da6ff !important; }}
 }}
 </style>
 </head>

--- a/static/reader.css
+++ b/static/reader.css
@@ -56,6 +56,15 @@ article {
     padding: 0.75rem 1rem;
 }
 
+.back-link {
+    display: inline-block;
+    margin-bottom: 0.5rem;
+    color: var(--meta-color);
+    text-decoration: none;
+    font-size: 0.9rem;
+}
+.back-link:hover { color: var(--text-color); text-decoration: underline; }
+
 header {
     border-bottom: 1px solid var(--border-color);
     padding-bottom: 0.5rem;
@@ -210,6 +219,25 @@ h1 {
   font-size: 0.9rem;
 }
 .site-nav .nav-link:hover { color: #222; }
+.site-nav__right {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.site-nav .nav-starred {
+  padding: 0.3rem 0.6rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 999px;
+  color: #555;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+.site-nav .nav-starred:hover { color: #222; border-color: #bbb; }
+.site-nav .nav-starred--active {
+  color: #f5a623;
+  border-color: #f5a623;
+  background: rgba(245, 166, 35, 0.08);
+}
 .site-nav .nav-search input[type="search"] {
   padding: 0.4rem 0.6rem;
   border: 1px solid #ccc;

--- a/templates/article.html
+++ b/templates/article.html
@@ -8,6 +8,7 @@
          data-is-read="{{ 'true' if is_read else 'false' }}"
          data-is-starred="{{ 'true' if is_starred else 'false' }}">
   <header>
+    <a href="/" class="back-link" aria-label="Back to landing">← Back</a>
     <h1>{{ subject }}</h1>
     <p class="meta">From: {{ sender }} | Date: {{ date }}</p>
     <div class="article-actions">

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,12 +11,20 @@
   <nav class="site-nav">
     <div class="site-nav__left">
       <a href="/" class="nav-home" aria-label="email2rss home">email2rss</a>
-      <a href="/article" class="nav-link">All Articles</a>
+      <a href="/" class="nav-link">All Articles</a>
       <a href="/list" class="nav-link">Raw Feeds</a>
     </div>
-    <form class="nav-search" action="/search" method="get">
-      <input type="search" name="q" placeholder="Search..." value="{{ search_q or '' }}" required>
-    </form>
+    <div class="site-nav__right">
+      <a href="{% if starred_only %}/{% else %}/?starred=1{% endif %}"
+         class="nav-link nav-starred{% if starred_only %} nav-starred--active{% endif %}"
+         aria-label="{% if starred_only %}Show all articles{% else %}Show starred only{% endif %}"
+         title="{% if starred_only %}Show all articles{% else %}Show starred only{% endif %}">
+        {% if starred_only %}★ Starred{% else %}☆ Starred{% endif %}
+      </a>
+      <form class="nav-search" action="/search" method="get">
+        <input type="search" name="q" placeholder="Search..." value="{{ search_q or '' }}" required>
+      </form>
+    </div>
   </nav>
   {% block body %}{% endblock %}
 </body>

--- a/tests/test_feed_server.py
+++ b/tests/test_feed_server.py
@@ -307,41 +307,30 @@ def test_star_route_allows_missing_origin(client, db_session):
     assert resp.status_code == 200
 
 
-def test_article_list_filter_unread(client, db_session):
+def test_landing_starred_filter_shows_only_starred(client, db_session):
     from tests.conftest import insert_email
-    a = insert_email(db_session, email_id=1, sender="s@example.com")
-    _b = insert_email(db_session, email_id=2, sender="s@example.com")
-    feed_server.db.mark_read(a.id, True)  # a is read
-
-    resp = client.get("/article?filter=unread")
-    assert resp.status_code == 200
-    body = resp.data.decode("utf-8")
-    # Unread list should contain b but not a
-    assert body.count('class="unread"') == 1  # one row with unread class
-
-
-def test_article_list_filter_starred(client, db_session):
-    from tests.conftest import insert_email
-    _a = insert_email(db_session, email_id=1, sender="s@example.com")
-    b = insert_email(db_session, email_id=2, sender="s@example.com")
+    _a = insert_email(db_session, email_id=1, sender="s@example.com",
+                      subject="Unstarred article X")
+    b = insert_email(db_session, email_id=2, sender="s@example.com",
+                     subject="Starred article Y")
     feed_server.db.mark_starred(b.id, True)
 
-    resp = client.get("/article?filter=starred")
+    resp = client.get("/?starred=1")
     assert resp.status_code == 200
     body = resp.data.decode("utf-8")
-    # Only one row should appear (the starred one)
-    assert body.count("<li ") == 1   # <li class="..." ...>
+    assert "Starred article Y" in body
+    assert "Unstarred article X" not in body
 
 
-def test_article_list_default_filter_is_all(client, db_session):
+def test_landing_without_starred_param_shows_all(client, db_session):
     from tests.conftest import insert_email
-    insert_email(db_session, email_id=1)
-    insert_email(db_session, email_id=2)
+    insert_email(db_session, email_id=1, subject="Article one")
+    insert_email(db_session, email_id=2, subject="Article two")
 
-    resp = client.get("/article")  # no filter param
+    resp = client.get("/")
     body = resp.data.decode("utf-8")
-    # Both rows present
-    assert body.count("<li ") == 2
+    assert "Article one" in body
+    assert "Article two" in body
 
 
 def test_search_route_returns_results(client, db_session):

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -245,17 +245,24 @@ def test_render_iframe_document_includes_csp_and_body():
     assert "<p>hi</p>" in doc
 
 
-def test_render_iframe_document_forces_dark_mode_via_filter():
+def test_render_iframe_document_strips_backgrounds_in_dark_mode():
     """
-    In dark mode we invert the html filter so inline email styles (bgcolor=#fff,
-    color:#000) flip to dark. Images/SVG/video get a canceling inverse filter
-    so photos and logos render with their true colors.
+    In dark mode we strip every explicit background so email content blends
+    into our dark canvas (more aesthetically unified than an inverted card).
+    Images/SVG/video/canvas are excluded from the strip so brand imagery
+    stays correct. Text is forced to a light color so inline dark colors
+    (common stibee pattern: color:#212121) don't vanish.
     """
     doc = reader.render_iframe_document("<p>hi</p>", proxy_origin="http://localhost:8000")
     assert "@media (prefers-color-scheme: dark)" in doc
-    assert "filter: invert(1) hue-rotate(180deg)" in doc
-    # Verify media elements get their own filter rule for cancellation
-    assert "img, svg, picture, video, canvas" in doc
+    assert "background-color: transparent !important" in doc
+    assert "background-image: none !important" in doc
+    # Media elements are excluded from the background strip
+    assert ":not(img):not(svg):not(picture):not(video):not(canvas)" in doc
+    # Text color is forced light
+    assert "color: #e5e5e5 !important" in doc
+    # Invert filter is NOT used anymore
+    assert "filter: invert" not in doc
 
 
 def _make_html_msg(html_body: str, sender="s@example.com"):


### PR DESCRIPTION
## Summary

Four related UI changes:

1. **Nav rewire** — "All Articles" now points to \`/\` (same as the brand logo). Removed the now-redundant \`/article\` GET route; its per-sender sibling \`/article/<feed_name>\` is untouched (still reachable via "See all" links on landing).

2. **Starred filter on landing** — new ☆/★ Starred toggle in the nav top-right. Clicking toggles \`?starred=1\` which filters the landing payload to \`is_starred=true\` rows. Active state shows a filled star with amber pill.

3. **Back link above article title** — subtle "← Back" link → \`/\`. Meta-colored; hover underlines.

4. **Dark mode: strip backgrounds instead of inverting** — dropped the invert filter in favor of stripping every explicit background inside the email so content blends into the dark canvas. More aesthetically unified than an inverted card. Images/SVG/video/canvas keep their own rendering (brand imagery stays correct). Text forced to \`#e5e5e5\` so inline \`color:#212121\` doesn't vanish; links stay a distinguishable \`#4da6ff\`.

## Test plan
- [x] 178/178 pytest pass
- [x] Replaced \`/article\` list-view tests with \`/?starred=1\` landing-filter tests
- [x] Updated dark-mode iframe CSS test to assert bg-strip + text-color rules, and the absence of \`filter: invert\`
- [ ] Post-merge: visual check — ★ Starred toggle filters landing, ← Back navigates home, moneyletter article in OS dark mode shows unified dark surface with readable text