### PR TITLE
feat(ui): auto-hide nav on scroll + redesign Raw Feeds page

### DIFF
--- a/database.py
+++ b/database.py
@@ -694,10 +694,19 @@ def _article_dict(row: Email, sign_url) -> dict:
     preview = row.preview_image_url
     image_url = sign_url(preview) if preview else None
 
+    # timestamp_iso: emit UTC ISO-8601 with a 'Z' suffix so the browser can
+    # parse with new Date() and do day-boundary comparisons in the user's
+    # local timezone. Server-side relative_date stays as a no-JS fallback.
+    if row.timestamp:
+        ts_iso = row.timestamp.replace(microsecond=0).isoformat() + "Z"
+    else:
+        ts_iso = ""
+
     return {
         "sender": row.sender,
         "subject": subject,
         "date_str": date_str,
+        "timestamp_iso": ts_iso,
         "relative_date": util.relative_date(row.timestamp) if row.timestamp else "",
         "guid": guid,
         "feed_name": _sanitize_feed_name(row.sender),

--- a/feed_server.py
+++ b/feed_server.py
@@ -230,7 +230,9 @@ def create_app() -> Flask:
             )
         except FileNotFoundError:
             entries = []
-        return render_template("list.html", entries=entries)
+        opml = next((e for e in entries if e.endswith(".opml")), None)
+        xml_entries = [e for e in entries if e.endswith(".xml")]
+        return render_template("list.html", entries=entries, opml=opml, xml_entries=xml_entries)
 
     @app.get("/img")
     def image_proxy_route():

--- a/static/reader.css
+++ b/static/reader.css
@@ -661,6 +661,7 @@ h1 {
 }
 
 .article-card__date {
+  display: block;
   font-size: 0.75rem;
   color: var(--meta-color);
   margin: 0;

--- a/static/reader.css
+++ b/static/reader.css
@@ -56,6 +56,133 @@ article {
     padding: 0.75rem 1rem;
 }
 
+/* ----------- Raw Feeds (/list) ----------- */
+.raw-feeds {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 1.25rem 1rem 3rem;
+}
+.raw-feeds__intro h1 {
+    font-size: 1.5rem;
+    letter-spacing: -0.01em;
+    margin: 0 0 0.25rem;
+}
+.raw-feeds__desc {
+    color: var(--meta-color);
+    font-size: 0.9rem;
+    margin: 0 0 1.25rem;
+}
+.raw-feeds__desc a {
+    color: var(--link-color);
+    text-decoration: none;
+}
+.raw-feeds__desc a:hover { text-decoration: underline; }
+
+.opml-card {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem 1.1rem;
+    margin-bottom: 2rem;
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    text-decoration: none;
+    color: inherit;
+    background: linear-gradient(135deg, rgba(0,102,204,0.06), rgba(245,166,35,0.04));
+    transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+.opml-card:hover {
+    transform: translateY(-1px);
+    border-color: var(--link-color);
+    box-shadow: 0 4px 14px rgba(0,0,0,0.08);
+}
+.opml-card__icon {
+    font-size: 1.6rem;
+    line-height: 1;
+    flex: 0 0 auto;
+}
+.opml-card__body { flex: 1 1 auto; }
+.opml-card__title {
+    font-size: 1rem;
+    margin: 0;
+    font-family: "SF Mono", Menlo, monospace;
+}
+.opml-card__desc {
+    color: var(--meta-color);
+    font-size: 0.85rem;
+    margin: 0.15rem 0 0;
+}
+.opml-card__chevron {
+    color: var(--meta-color);
+    font-size: 1.2rem;
+    flex: 0 0 auto;
+    transition: transform 0.15s ease;
+}
+.opml-card:hover .opml-card__chevron { transform: translateX(3px); color: var(--link-color); }
+
+.raw-feeds__section-title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0 0 0.75rem;
+    color: var(--text-color);
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+}
+.raw-feeds__count {
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: var(--meta-color);
+    background: var(--code-bg);
+    padding: 0.1rem 0.5rem;
+    border-radius: 10px;
+}
+
+.feed-grid {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 0.5rem;
+}
+.feed-chip {
+    display: flex;
+    align-items: baseline;
+    gap: 0.4rem;
+    padding: 0.55rem 0.8rem;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    text-decoration: none;
+    color: var(--text-color);
+    background: var(--card-bg);
+    font-family: "SF Mono", Menlo, monospace;
+    font-size: 0.85rem;
+    transition: border-color 0.12s ease, background 0.12s ease, transform 0.12s ease;
+    overflow: hidden;
+}
+.feed-chip:hover {
+    border-color: var(--link-color);
+    background: rgba(0, 102, 204, 0.04);
+    transform: translateY(-1px);
+}
+.feed-chip__name {
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.feed-chip__ext {
+    flex: 0 0 auto;
+    color: var(--meta-color);
+    font-size: 0.75rem;
+}
+.raw-feeds__empty {
+    color: var(--meta-color);
+    text-align: center;
+    padding: 3rem 1rem;
+}
+
 .back-link {
     display: inline-block;
     margin-bottom: 0.5rem;
@@ -194,11 +321,17 @@ h1 {
   padding: 0.75rem 1rem;
   border-bottom: 1px solid #e0e0e0;
   background: #fafafa;
-  /* Sticky so the nav stays visible while the article scrolls, matching the
-     landing page behavior and the original Netflix-style mockup. */
+  /* Sticky with auto-hide: JS toggles .site-nav--hidden on scroll direction,
+     and the transform transition slides the nav out of / back into view. */
   position: sticky;
   top: 0;
   z-index: 10;
+  transform: translateY(0);
+  transition: transform 0.25s ease;
+  will-change: transform;
+}
+.site-nav--hidden {
+  transform: translateY(-100%);
 }
 .site-nav__left {
   display: flex;

--- a/static/reader.js
+++ b/static/reader.js
@@ -89,6 +89,40 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 });
 
+// --- Nav auto-hide on scroll ---
+// Hide the sticky site-nav when the user scrolls down past the nav height;
+// reveal it again on any upward scroll. Matches the common mobile pattern
+// where the nav gets out of the way while reading and comes back when the
+// user wants to navigate.
+(() => {
+  const nav = document.querySelector('.site-nav');
+  if (!nav) return;
+  let lastY = window.scrollY;
+  let ticking = false;
+  const threshold = nav.offsetHeight + 30;
+
+  function onScroll() {
+    const y = window.scrollY;
+    // Always show near the top (so refreshed pages don't start hidden)
+    if (y < threshold) {
+      nav.classList.remove('site-nav--hidden');
+    } else if (y > lastY + 4) {
+      nav.classList.add('site-nav--hidden');
+    } else if (y < lastY - 4) {
+      nav.classList.remove('site-nav--hidden');
+    }
+    lastY = y;
+    ticking = false;
+  }
+
+  window.addEventListener('scroll', () => {
+    if (!ticking) {
+      requestAnimationFrame(onScroll);
+      ticking = true;
+    }
+  }, { passive: true });
+})();
+
 // --- Unread-dot optimistic update ---
 // When the user clicks a card, note its href in sessionStorage. On pageshow
 // (including bfcache restore, which hands back the stale landing DOM),

--- a/static/reader.js
+++ b/static/reader.js
@@ -89,6 +89,45 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 });
 
+// --- Client-side relative date (Korean) ---
+// Server renders a fallback based on its UTC clock; we recompute using the
+// browser's local time so day-boundary categories ("어제", "N일 전") match
+// the user's wall clock instead of UTC.
+function formatRelativeKo(dt, now) {
+  const deltaMs = now - dt;
+  const deltaSec = deltaMs / 1000;
+  if (deltaSec < 60) return '방금 전';
+  if (deltaSec < 3600) return `${Math.floor(deltaSec / 60)}분 전`;
+
+  // Calendar-day comparison uses local-time (y/m/d from getFullYear/Month/Date)
+  const sameLocalDay = dt.getFullYear() === now.getFullYear()
+    && dt.getMonth() === now.getMonth()
+    && dt.getDate() === now.getDate();
+  if (sameLocalDay) return `${Math.floor(deltaSec / 3600)}시간 전`;
+
+  const yesterday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1);
+  const isYesterday = dt.getFullYear() === yesterday.getFullYear()
+    && dt.getMonth() === yesterday.getMonth()
+    && dt.getDate() === yesterday.getDate();
+  if (isYesterday) return '어제';
+
+  const days = Math.floor(deltaSec / 86400);
+  if (days < 7) return `${days}일 전`;
+  if (days < 30) return `${Math.floor(days / 7)}주 전`;
+  if (days < 365) return `${Math.floor(days / 30)}개월 전`;
+  return `${Math.floor(days / 365)}년 전`;
+}
+document.addEventListener('DOMContentLoaded', () => {
+  const now = new Date();
+  document.querySelectorAll('time[data-rel][datetime]').forEach((el) => {
+    const iso = el.getAttribute('datetime');
+    if (!iso) return;
+    const dt = new Date(iso);
+    if (isNaN(dt.getTime())) return;
+    el.textContent = formatRelativeKo(dt, now);
+  });
+});
+
 // --- Nav auto-hide on scroll ---
 // Hide the sticky site-nav when the user scrolls down past the nav height;
 // reveal it again on any upward scroll. Matches the common mobile pattern

--- a/templates/_cards.html
+++ b/templates/_cards.html
@@ -37,7 +37,7 @@
         {{ article.sender.split("@")[1] if "@" in article.sender else article.sender }}
       </p>
       <h3 class="article-card__subject">{{ article.subject }}</h3>
-      <p class="article-card__date">{{ article.relative_date }}</p>
+      <time class="article-card__date" datetime="{{ article.timestamp_iso }}" data-rel>{{ article.relative_date }}</time>
       {% if not article.is_read %}<span class="article-card__unread-dot" aria-label="unread"></span>{% endif %}
     </div>
   </a>
@@ -48,7 +48,7 @@
     <div class="article-card__thumb">{{ _thumb(article) }}</div>
     <div class="article-card__body">
       <h3 class="article-card__subject">{{ article.subject }}</h3>
-      <p class="article-card__date">{{ article.relative_date }}</p>
+      <time class="article-card__date" datetime="{{ article.timestamp_iso }}" data-rel>{{ article.relative_date }}</time>
       {% if not article.is_read %}<span class="article-card__unread-dot" aria-label="unread"></span>{% endif %}
     </div>
   </a>

--- a/templates/list.html
+++ b/templates/list.html
@@ -1,15 +1,41 @@
 {% extends "base.html" %}
-{% block title %}email2rss — XML feed list{% endblock %}
+{% block title %}email2rss — Raw Feeds{% endblock %}
 {% block body %}
-<h1>RSS Feeds (XML)</h1>
-<p>Direct XML URLs for RSS readers. For the styled landing, <a href="/">go back to /</a>.</p>
-{% if entries %}
-<ul>
-  {% for name in entries %}
-    <li><a href="/{{ name }}">{{ name }}</a></li>
-  {% endfor %}
-</ul>
-{% else %}
-<p>No feeds yet. The IMAP fetcher will populate feeds once emails are fetched and RSS files are generated.</p>
-{% endif %}
+<main class="raw-feeds">
+  <header class="raw-feeds__intro">
+    <h1>Raw Feeds</h1>
+    <p class="raw-feeds__desc">
+      Direct XML URLs for RSS readers. For the styled landing, <a href="/">go back to /</a>.
+    </p>
+  </header>
+
+  {% if opml %}
+  <a href="/{{ opml }}" class="opml-card">
+    <span class="opml-card__icon" aria-hidden="true">📥</span>
+    <div class="opml-card__body">
+      <h2 class="opml-card__title">{{ opml }}</h2>
+      <p class="opml-card__desc">Import every feed at once — drop this URL into your RSS reader.</p>
+    </div>
+    <span class="opml-card__chevron" aria-hidden="true">→</span>
+  </a>
+  {% endif %}
+
+  {% if xml_entries %}
+  <section class="raw-feeds__section">
+    <h2 class="raw-feeds__section-title">Individual feeds <span class="raw-feeds__count">{{ xml_entries|length }}</span></h2>
+    <ul class="feed-grid">
+      {% for name in xml_entries %}
+        <li>
+          <a href="/{{ name }}" class="feed-chip">
+            <span class="feed-chip__name">{{ name[:-4] }}</span>
+            <span class="feed-chip__ext">.xml</span>
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+  {% elif not opml %}
+  <p class="raw-feeds__empty">No feeds yet. The IMAP fetcher will populate feeds once emails are fetched.</p>
+  {% endif %}
+</main>
 {% endblock %}


### PR DESCRIPTION
## Summary
Three UI polish items:

1. **Nav auto-hide on scroll.** Scroll down → nav slides out (translateY(-100%)). Scroll up → nav slides back in. Always visible when near top of page. rAF-throttled scroll handler, 4px hysteresis to avoid jitter, 250ms ease transition.

2. **Raw Feeds page redesign.** Default ul/li/blue-link aesthetic replaced with:
   - Highlighted OPML card at top ("Import every feed at once")
   - Responsive auto-fill grid of monospace chips for individual .xml feeds
   - Hover lift + brand-blue border on chips
   - Count badge
   - All uses existing CSS variables → dark-mode parity automatic

3. **Client-side relative date.** Server was computing "어제" / "N시간 전" using UTC day boundaries; KST users saw "어제" for articles that arrived earlier today in local time. Now emits \`timestamp_iso\` (UTC Z) per card, renders as \`<time datetime=... data-rel>\`, and reader.js recomputes with \`new Date()\` so day categories match the user's wall clock. Server-rendered string stays as no-JS fallback.

## Test plan
- [x] 178/178 pytest pass
- [ ] Post-merge: scroll down/up toggles nav; /list shows card grid; date labels reflect local time (not UTC)