### PR TITLE
fix(reader): include <body> in dark-mode bg strip

### DIFF
--- a/reader.py
+++ b/reader.py
@@ -264,8 +264,11 @@ a {{ color: #0066cc; }}
      newsletters hard-code dark text (e.g. color:#212121) that would vanish
      on a dark background if we only stripped the bg. Links keep a
      distinguishable blue. */
-  html, body {{ background: #1a1a1a; color: #e5e5e5; }}
-  body *:not(img):not(svg):not(picture):not(video):not(canvas) {{
+  html {{ background: #1a1a1a; }}
+  /* body AND its descendants get bg stripped — some newsletters set
+     `background-color` directly on <body>, so a descendant-only selector
+     would miss them. */
+  body, body *:not(img):not(svg):not(picture):not(video):not(canvas) {{
     background-color: transparent !important;
     background-image: none !important;
   }}

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -259,6 +259,10 @@ def test_render_iframe_document_strips_backgrounds_in_dark_mode():
     assert "background-image: none !important" in doc
     # Media elements are excluded from the background strip
     assert ":not(img):not(svg):not(picture):not(video):not(canvas)" in doc
+    # The bg-strip selector MUST include body itself — some newsletters set
+    # background-color directly on <body>, so a descendant-only selector
+    # (body *) would leave that inline light bg in place on our dark canvas.
+    assert "body, body *:not(img):not(svg):not(picture):not(video):not(canvas)" in doc
     # Text color is forced light
     assert "color: #e5e5e5 !important" in doc
     # Invert filter is NOT used anymore


### PR DESCRIPTION
## Summary
Observed on https://email2rss.1kko.com/article/team_soonsal_com/... in OS dark mode: the whole email rendered on a cream (\`rgb(245,245,240)\`) background instead of our dark canvas. DOM inspection confirmed the email's \`<body>\` itself carries an inline cream background.

Our previous bg-strip selector was \`body *:not(img):not(svg):not(picture):not(video):not(canvas)\` — descendants only. The \`<body>\` element itself was never matched, so the cream inline style survived. Combined selector \`body, body *:not(media)\` now covers both.

## Test plan
- [x] 178/178 pytest pass
- [x] Added assertion for the combined selector so future changes can't silently drop \`body\` from the rule
- [ ] Post-merge visual check on the soonsal article in OS dark mode — content should blend into the dark canvas, not sit on a cream card