### PR TITLE
fix(reader): kill iframe inner scroll + size before load event

### DIFF
--- a/reader.py
+++ b/reader.py
@@ -239,14 +239,16 @@ _IFRAME_TEMPLATE = """\
 <base target="_blank">
 <style>
 body {{ font: 16px/1.5 -apple-system, system-ui, sans-serif; color: #222; margin: 0 1rem; }}
-/* Hide the iframe's own scrollbar — parent JS auto-sizes the iframe to its
-   content height, so the outer page is the one that scrolls. Without this,
-   long emails flash an inner scrollbar during load until ResizeObserver
-   fires and grows the iframe. Purely cosmetic; content is not clipped. */
-html {{ scrollbar-width: none; }}
-html::-webkit-scrollbar {{ display: none; }}
-body {{ scrollbar-width: none; }}
-body::-webkit-scrollbar {{ display: none; }}
+/* Kill the iframe's own scroll entirely — parent JS auto-sizes the iframe
+   to its content height, so the outer page is the one that scrolls. Before
+   this, long emails let the user scroll *inside* the iframe while JS was
+   still measuring, so content scrolled for a moment and then "snapped" to
+   the full height once load fired. overflow:hidden prevents any inner
+   scroll from occurring, and scrollbar-width:none hides the phantom
+   scrollbar space. Clipped content appears once JS runs (fast path below
+   fires on first rAF, not waiting for `load`). */
+html, body {{ overflow: hidden; scrollbar-width: none; }}
+html::-webkit-scrollbar, body::-webkit-scrollbar {{ display: none; }}
 /* Center block-level email content. Newsletter templates commonly use
    fixed-width tables (e.g. width:600px) laid out flush-left; `margin: 0 auto`
    centers them within the iframe viewport. Content without a fixed width

--- a/static/reader.js
+++ b/static/reader.js
@@ -63,8 +63,16 @@ document.addEventListener('DOMContentLoaded', () => {
   // continuous scroll (no nested scrollbar). Requires allow-same-origin in
   // the iframe sandbox — safe because the inner CSP still forbids scripts,
   // so the iframe can't run JS to exploit same-origin access.
+  //
+  // We start observing BEFORE the iframe's `load` event — load waits for
+  // every subresource (images), which means long emails showed partial
+  // content at 80vh with inner scroll until load finally fired. Polling
+  // via requestAnimationFrame until body exists catches the iframe right
+  // after srcdoc is parsed, so the first paint already has the right
+  // height. ResizeObserver + image-load hooks handle later layout shifts.
   const iframe = document.getElementById('email-body');
   if (iframe) {
+    let observerAttached = false;
     const resize = () => {
       try {
         const doc = iframe.contentDocument;
@@ -76,16 +84,31 @@ document.addEventListener('DOMContentLoaded', () => {
         if (h > 0) iframe.style.height = h + 'px';
       } catch (_) { /* cross-origin or not loaded yet */ }
     };
-    iframe.addEventListener('load', () => {
-      resize();
+    const attachObservers = () => {
+      if (observerAttached) return;
       try {
-        const ro = new ResizeObserver(resize);
-        if (iframe.contentDocument?.body) ro.observe(iframe.contentDocument.body);
-      } catch (_) { /* ResizeObserver unsupported — fall back to image-load hook */ }
-      iframe.contentDocument?.querySelectorAll('img').forEach((img) => {
-        if (!img.complete) img.addEventListener('load', resize);
-      });
-    });
+        const body = iframe.contentDocument && iframe.contentDocument.body;
+        if (!body) return;
+        observerAttached = true;
+        resize();
+        try {
+          const ro = new ResizeObserver(resize);
+          ro.observe(body);
+        } catch (_) { /* ResizeObserver unsupported — image-load hook below still runs */ }
+        iframe.contentDocument.querySelectorAll('img').forEach((img) => {
+          if (!img.complete) img.addEventListener('load', resize);
+        });
+      } catch (_) { /* body not yet ready */ }
+    };
+    // Fast path: poll via rAF until body exists, usually within 1 frame of
+    // srcdoc parse — runs well before the iframe's `load` event.
+    const tryNow = () => {
+      attachObservers();
+      if (!observerAttached) requestAnimationFrame(tryNow);
+    };
+    tryNow();
+    // Safety net: also handle the load event in case rAF polling missed.
+    iframe.addEventListener('load', attachObservers);
   }
 });
 


### PR DESCRIPTION
## Summary
Reported on https://email2rss.1kko.com/article/everybody_booding_co/... — long articles let the user scroll *inside* the iframe while we waited for the iframe's \`load\` event to fire. Once it fired, the iframe snapped from 80vh to full content height and the parent scroll took over. Jarring.

Two changes address it:

1. **Srcdoc \`overflow: hidden\` on html/body.** Inner scroll can never happen. Parent is always the only scroll surface. Before JS runs, content beyond the initial height is visually clipped, but it reappears within a frame (change 2 below).

2. **Start observing before \`load\`.** \`load\` waits for every subresource (images in 600×400 newsletters add up). reader.js now rAF-polls for \`iframe.contentDocument.body\`; as soon as the body exists (right after srcdoc is parsed) we resize and attach ResizeObserver. The \`load\` handler stays as a safety net.

## Test plan
- [x] 178/178 pytest pass
- [ ] Post-merge: booding article loads as a single continuous scroll — no inner scroll window while images are still downloading