### PR TITLE
fix(reader): force loading=eager on email images

### DIFF
--- a/reader.py
+++ b/reader.py
@@ -103,7 +103,12 @@ ALLOWED_TAGS = frozenset({
 ALLOWED_ATTRS = {
     "*": ["class", "id", "style", "title"],
     "a": ["href", "target", "rel"],
-    "img": ["alt", "src", "width", "height"],
+    # "loading" allowed so we can force eager-loading in ImageRewriter. Without
+    # it, browsers' auto lazy-load heuristic defers images below the fold;
+    # combined with our overflow:hidden iframe body those images never enter a
+    # viewport, so they never load and the iframe's scrollHeight never reaches
+    # its true value. Forcing loading=eager keeps the autosize deterministic.
+    "img": ["alt", "src", "width", "height", "loading"],
     "td": ["colspan", "rowspan"],
     "th": ["colspan", "rowspan"],
     "time": ["datetime"],
@@ -124,6 +129,7 @@ def _make_image_rewriter(cid_map: dict[str, str], sign_url: Callable[[str], str]
                     attrs = dict(token.get("data") or {})
                     src_key = (None, "src")
                     srcset_key = (None, "srcset")
+                    loading_key = (None, "loading")
                     src = attrs.get(src_key, "")
                     attrs.pop(srcset_key, None)
 
@@ -132,6 +138,8 @@ def _make_image_rewriter(cid_map: dict[str, str], sign_url: Callable[[str], str]
                         # Drop the tag entirely by skipping the token
                         continue
                     attrs[src_key] = new_src
+                    # Force eager loading — see ALLOWED_ATTRS comment for why.
+                    attrs[loading_key] = "eager"
                     token["data"] = attrs
                 yield token
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -118,6 +118,23 @@ def test_clean_rewrites_http_img():
     assert 'src="SIGN:http://cdn.example.com/x.png"' in out
 
 
+def test_clean_forces_eager_loading_on_images():
+    """
+    iframe body uses overflow:hidden so below-fold images never enter their
+    own viewport → browsers' auto lazy-load keeps them unresolved → iframe's
+    scrollHeight never reaches its true value and autosize stalls. Every
+    <img> must come out with loading="eager".
+    """
+    out = reader.clean_and_rewrite(
+        '<img src="http://x.com/a.png"><img src="http://x.com/b.png" loading="lazy">',
+        {},
+        _identity_sign,
+    )
+    # Both images get loading=eager, overriding any inline lazy attr
+    assert out.count('loading="eager"') == 2
+    assert 'loading="lazy"' not in out
+
+
 def test_clean_rewrites_https_img():
     out = reader.clean_and_rewrite('<img src="https://cdn.example.com/x.png">', {}, _identity_sign)
     assert 'src="SIGN:https://cdn.example.com/x.png"' in out


### PR DESCRIPTION
## Summary
PR #31 set \`overflow: hidden\` on the iframe body so there's no inner scroll. Downside flagged by user: images below the iframe's initial viewport never enter any viewport (because the iframe doesn't scroll), so browsers' auto lazy-load heuristic keeps them unresolved forever. Without their real dimensions, \`contentDocument.body.scrollHeight\` stays short and the iframe never grows to its true height — the page feels like it's still loading.

Fix: ImageRewriter now writes \`loading="eager"\` on every \`<img>\` it emits. Every image fires immediately, the ResizeObserver catches each load, and the iframe reaches full height with no user interaction.

## Test plan
- [x] 179/179 pytest pass (1 new)
- [x] \`test_clean_forces_eager_loading_on_images\` — asserts \`loading="eager"\` is added to every img, overriding any inline \`loading="lazy"\`
- [ ] Post-merge: booding article (and other long, image-heavy emails) finishes loading and renders at full height without scrolling